### PR TITLE
Optimized BSpline find_bounding functions

### DIFF
--- a/ov_core/src/sim/Simulator.cpp
+++ b/ov_core/src/sim/Simulator.cpp
@@ -38,7 +38,7 @@ Simulator::Simulator(ros::NodeHandle& nh) {
     ROS_INFO("=======================================");
 
     // Load the groundtruth trajectory and its spline
-    std::string path_traj = "/home/patrick/workspace/catkin_ws_ov/src/open_vins/ov_data/sim/udel_gore.txt";
+    std::string path_traj = "./src/open_vins/ov_data/sim/udel_gore.txt";
     nh.param<std::string>("sim_traj_path", path_traj, path_traj);
     load_data(path_traj);
     spline.feed_trajectory(traj_data);


### PR DESCRIPTION
I changed the BSpline find_bounding functions to utilize the map characteristics.

For "find_bounding_poses" this means utilizing the upper and lower bound functions to find the timestamps.

For "find_bounding_control_points" it will find the iterators associate with the bounding pose timestamps and then use those to find the below and above timestamps.

On my admittingly terrible laptop. The differences are 7 seconds without and 1.3 seconds with these optimizations on the test_sim.cpp file (Just running the sim not the data creation).

P.S 
- Also changed the simulator to not reference Mr. Geneva's home directory by default for the data file.
- Could we get a clang format file. I tried my best to match conventions, but it would be nice if I could run it through a formatter.