### PR TITLE
Make publishing global to imu TF optional

### DIFF
--- a/ov_msckf/src/core/RosVisualizer.cpp
+++ b/ov_msckf/src/core/RosVisualizer.cpp
@@ -59,6 +59,9 @@ RosVisualizer::RosVisualizer(ros::NodeHandle &nh, VioManager* app, Simulator *si
     pub_pathgt = nh.advertise<nav_msgs::Path>("/ov_msckf/pathgt", 2);
     ROS_INFO("Publishing: %s", pub_pathgt.getTopic().c_str());
 
+    // option to enable publishing of global to IMU transformation
+    nh.param<bool>("publish_global_to_imu_tf", publish_global2imu_tf, true);
+
     // Load groundtruth if we have it and are not doing simulation
     if (nh.hasParam("path_gt") && _sim==nullptr) {
         std::string path_to_gt;
@@ -331,7 +334,9 @@ void RosVisualizer::publish_state() {
     trans.setRotation(quat);
     tf::Vector3 orig(state->_imu->pos()(0),state->_imu->pos()(1),state->_imu->pos()(2));
     trans.setOrigin(orig);
-    mTfBr->sendTransform(trans);
+    if(publish_global2imu_tf) {
+        mTfBr->sendTransform(trans);
+    }
 
     // Loop through each camera calibration and publish it
     for(const auto &calib : state->_calib_IMUtoCAM) {

--- a/ov_msckf/src/core/RosVisualizer.h
+++ b/ov_msckf/src/core/RosVisualizer.h
@@ -148,6 +148,7 @@ namespace ov_msckf {
         // For path viz
         unsigned int poses_seq_gt = 0;
         vector<geometry_msgs::PoseStamped> poses_gt;
+        bool publish_global2imu_tf = true;
 
         // Files and if we should save total state
         bool save_total_state;


### PR DESCRIPTION
This is useful for applications that republish this data on its own TF tree