### PR TITLE
Development v2.1 - Secondary Pose Graph Support

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -19,6 +19,7 @@ Please take a look at the feature list below for full details on what the system
 
 ## News / Events
 
+* **May 18, 2020** - Released secondary pose graph example repository [ov_secondary](https://github.com/rpng/ov_secondary) based on [VINS-Fusion](https://github.com/HKUST-Aerial-Robotics/VINS-Fusion). OpenVINS now publishes marginalized feature track, feature 3d position, and first camera intrinsics and extrinsics. See [PR#66](https://github.com/rpng/open_vins/pull/66) for details and discussion.
 * **April 3, 2020** - Released [v2.0](https://github.com/rpng/open_vins/releases/tag/v2.0) update to the codebase with some key refactoring, ros-free building, improved dataset support, and single inverse depth feature representation. Please check out the [release page](https://github.com/rpng/open_vins/releases/tag/v2.0) for details.
 * **January 21, 2020** - Our paper has been accepted for presentation in [ICRA 2020](https://www.icra2020.org/). We look forward to seeing everybody there! We have also added links to a few videos of the system running on different datasets.
 * **October 23, 2019** - OpenVINS placed first in the [IROS 2019 FPV Drone Racing VIO Competition
@@ -63,8 +64,26 @@ Please take a look at the feature list below for full details on what the system
 * Out of the box evaluation on EurocMav and TUM-VI datasets
 * Extensive evaluation suite (ATE, RPE, NEES, RMSE, etc..)
 
-## Demo Videos
 
+
+## Codebase Extensions
+
+* **[ov_secondary](https://github.com/rpng/ov_secondary)** -
+This is an example secondary thread which provides loop closure in a loosely coupled manner for [OpenVINS](https://github.com/rpng/open_vins).
+This is a modification of the code originally developed by the HKUST aerial robotics group and can be found in their [VINS-Fusion](https://github.com/HKUST-Aerial-Robotics/VINS-Fusion) repository.
+Here we stress that this is a loosely coupled method, thus no information is returned to the estimator to improve the underlying OpenVINS odometry.
+This codebase has been modified in a few key areas including: exposing more loop closure parameters, subscribing to camera intrinsics, simplifying configuration such that only topics need to be supplied, and some tweaks to the loop closure detection to improve frequency.
+
+* **[ov_maplab](https://github.com/rpng/ov_maplab)** - 
+This codebase contains the interface wrapper for exporting visual-inertial runs from [OpenVINS](https://github.com/rpng/open_vins) into the ViMap structure taken by [maplab](https://github.com/ethz-asl/maplab).
+The state estimates and raw images are appended to the ViMap as OpenVINS runs through a dataset.
+After completion of the dataset, features are re-extract and triangulate with maplab's feature system.
+This can be used to merge multi-session maps, or to perform a batch optimization after first running the data through OpenVINS.
+Some example have been provided along with a helper script to export trajectories into the standard groundtruth format.
+
+
+
+## Demo Videos
 
 [![](docs/youtube/KCX51GvYGss.jpg)](http://www.youtube.com/watch?v=KCX51GvYGss "OpenVINS - EuRoC MAV Vicon Rooms Flyby")
 [![](docs/youtube/Lc7VQHngSuQ.jpg)](http://www.youtube.com/watch?v=Lc7VQHngSuQ "OpenVINS - TUM VI Datasets Flyby")
@@ -74,6 +93,7 @@ Please take a look at the feature list below for full details on what the system
 [![](docs/youtube/187AXuuGNNw.jpg)](http://www.youtube.com/watch?v=187AXuuGNNw "OpenVINS - EuRoC MAV Vicon Rooms Demonstration")
 [![](docs/youtube/oUoLlrFryk0.jpg)](http://www.youtube.com/watch?v=oUoLlrFryk0 "OpenVINS - TUM VI Datasets Demostration")
 [![](docs/youtube/ExPIGwORm4E.jpg)](http://www.youtube.com/watch?v=ExPIGwORm4E "OpenVINS - UZH-FPV Drone Racing Dataset Demonstration")
+
 
 
 ## Credit / Licensing

--- a/ov_msckf/launch/pgeneva_ros_tum.launch
+++ b/ov_msckf/launch/pgeneva_ros_tum.launch
@@ -4,11 +4,11 @@
     <arg name="max_cameras" default="2" />
     <arg name="use_stereo"  default="true" />
     <arg name="bag_start"   default="0" />
-    <arg name="bag"         default="/home/patrick/datasets/tum/dataset-room2_512_16.bag" />
+    <arg name="bag"         default="/home/patrick/datasets/tum/dataset-room1_512_16.bag" />
 
     <!-- imu starting thresholds -->
     <arg name="init_window_time"  default="1.0" />
-    <arg name="init_imu_thresh"   default="0.75" />
+    <arg name="init_imu_thresh"   default="0.70" /> <!-- room1:0.70, room2:0.75, room3:0.70 -->
 
     <!-- saving trajectory path and timing information -->
     <arg name="dosave"      default="false" />

--- a/ov_msckf/launch/pgeneva_serial_tum.launch
+++ b/ov_msckf/launch/pgeneva_serial_tum.launch
@@ -32,7 +32,7 @@
         <param name="max_cameras"            type="int"    value="2" />
         <param name="dt_slam_delay"          type="double" value="3" />
         <param name="init_window_time"       type="double" value="1.0" />
-        <param name="init_imu_thresh"        type="double" value="0.8" />
+        <param name="init_imu_thresh"        type="double" value="0.70" /> <!-- room1:0.70, room2:0.75, room3:0.70 -->
         <rosparam param="gravity">[0.0,0.0,9.80766]</rosparam>
         <param name="feat_rep_msckf"         type="string" value="GLOBAL_3D" />
         <param name="feat_rep_slam"          type="string" value="ANCHORED_FULL_INVERSE_DEPTH" />

--- a/ov_msckf/src/core/RosVisualizer.h
+++ b/ov_msckf/src/core/RosVisualizer.h
@@ -27,8 +27,10 @@
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/NavSatFix.h>
+#include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
+#include <sensor_msgs/CameraInfo.h>
 #include <std_msgs/Float64.h>
 #include <nav_msgs/Path.h>
 #include <nav_msgs/Odometry.h>
@@ -102,6 +104,9 @@ namespace ov_msckf {
         /// Publish groundtruth (if we have it)
         void publish_groundtruth();
 
+        /// Publish keyframe information of the marginalized pose and tracks
+        void publish_keyframe_information();
+
         /// Save current estimate state and groundtruth including calibration
         void sim_save_total_state_to_file();
 
@@ -115,14 +120,10 @@ namespace ov_msckf {
         Simulator* _sim;
 
         // Our publishers
-        ros::Publisher pub_poseimu;
-        ros::Publisher pub_odomimu;
-        ros::Publisher pub_pathimu;
-        ros::Publisher pub_points_msckf;
-        ros::Publisher pub_points_slam;
-        ros::Publisher pub_points_aruco;
-        ros::Publisher pub_points_sim;
+        ros::Publisher pub_poseimu, pub_odomimu, pub_pathimu;
+        ros::Publisher pub_points_msckf, pub_points_slam, pub_points_aruco, pub_points_sim;
         ros::Publisher pub_tracks;
+        ros::Publisher pub_keyframe_pose, pub_keyframe_point, pub_keyframe_extrinsic, pub_keyframe_intrinsics;
         tf::TransformBroadcaster *mTfBr;
 
         // For path viz
@@ -130,8 +131,7 @@ namespace ov_msckf {
         vector<geometry_msgs::PoseStamped> poses_imu;
 
         // Groundtruth infomation
-        ros::Publisher pub_pathgt;
-        ros::Publisher pub_posegt;
+        ros::Publisher pub_pathgt, pub_posegt;
         double summed_rmse_ori = 0.0;
         double summed_rmse_pos = 0.0;
         double summed_nees_ori = 0.0;

--- a/ov_msckf/src/core/VioManager.cpp
+++ b/ov_msckf/src/core/VioManager.cpp
@@ -494,81 +494,11 @@ void VioManager::do_feature_propagate_update(double timestamp) {
     //===================================================================================
 
 
-
-    //===================================================================================
-    //===================================================================================
-    //===================================================================================
-    // Loop through all MSCKF features
-    for(const auto &feat : featsup_MSCKF) {
-        // Get position of feature in the global frame of reference
-        Eigen::Vector3d p_FinG = feat->p_FinG;
-        // Push back this new best estimate to our historical maps
-        if(hist_feat_posinG.find(feat->featid)!=hist_feat_posinG.end()) {
-            hist_feat_posinG.at(feat->featid) = p_FinG;
-            for(const auto &cam2uv : feat->uvs) {
-                if(hist_feat_uvs.at(feat->featid).find(cam2uv.first)!=hist_feat_uvs.at(feat->featid).end()) {
-                    hist_feat_uvs.at(feat->featid).at(cam2uv.first).insert(hist_feat_uvs.at(feat->featid).at(cam2uv.first).end(), cam2uv.second.begin(), cam2uv.second.end());
-                    hist_feat_uvs_norm.at(feat->featid).at(cam2uv.first).insert(hist_feat_uvs_norm.at(feat->featid).at(cam2uv.first).end(), feat->uvs_norm.at(cam2uv.first).begin(), feat->uvs_norm.at(cam2uv.first).end());
-                    hist_feat_timestamps.at(feat->featid).at(cam2uv.first).insert(hist_feat_timestamps.at(feat->featid).at(cam2uv.first).end(), feat->timestamps.at(cam2uv.first).begin(), feat->timestamps.at(cam2uv.first).end());
-                } else {
-                    hist_feat_uvs.at(feat->featid).insert(cam2uv);
-                    hist_feat_uvs_norm.at(feat->featid).insert({cam2uv.first,feat->uvs_norm.at(cam2uv.first)});
-                    hist_feat_timestamps.at(feat->featid).insert({cam2uv.first,feat->timestamps.at(cam2uv.first)});
-                }
-            }
-        } else {
-            hist_feat_posinG.insert({feat->featid,p_FinG});
-            hist_feat_uvs.insert({feat->featid,feat->uvs});
-            hist_feat_uvs_norm.insert({feat->featid,feat->uvs_norm});
-            hist_feat_timestamps.insert({feat->featid,feat->timestamps});
-        }
-    }
-    // SLAM features
-    std::vector<Feature*> featsup_SLAM = feats_slam_UPDATE;
-    featsup_SLAM.insert(featsup_SLAM.end(), feats_slam_DELAYED.begin(), feats_slam_DELAYED.end());
-    for(const auto &feat : featsup_SLAM) {
-        // Ensure this feature is in our state vector
-        if(state->_features_SLAM.find(feat->featid)==state->_features_SLAM.end()) {
-            printf(RED "[ERROR]: slam feature not found in state, but is reported as being in state by updater!\n" RESET);
-            continue;
-        }
-        // Get position of feature in the global frame of reference
-        Eigen::Vector3d p_FinG = state->_features_SLAM.at(feat->featid)->get_xyz(false);
-        // Push back this new best estimate to our historical maps
-        if(hist_feat_posinG.find(feat->featid)!=hist_feat_posinG.end()) {
-            hist_feat_posinG.at(feat->featid) = p_FinG;
-            for(const auto &cam2uv : feat->uvs) {
-                if(hist_feat_uvs.at(feat->featid).find(cam2uv.first)!=hist_feat_uvs.at(feat->featid).end()) {
-                    hist_feat_uvs.at(feat->featid).at(cam2uv.first).insert(hist_feat_uvs.at(feat->featid).at(cam2uv.first).end(), cam2uv.second.begin(), cam2uv.second.end());
-                    hist_feat_uvs_norm.at(feat->featid).at(cam2uv.first).insert(hist_feat_uvs_norm.at(feat->featid).at(cam2uv.first).end(), feat->uvs_norm.at(cam2uv.first).begin(), feat->uvs_norm.at(cam2uv.first).end());
-                    hist_feat_timestamps.at(feat->featid).at(cam2uv.first).insert(hist_feat_timestamps.at(feat->featid).at(cam2uv.first).end(), feat->timestamps.at(cam2uv.first).begin(), feat->timestamps.at(cam2uv.first).end());
-                } else {
-                    hist_feat_uvs.at(feat->featid).insert(cam2uv);
-                    hist_feat_uvs_norm.at(feat->featid).insert({cam2uv.first,feat->uvs_norm.at(cam2uv.first)});
-                    hist_feat_timestamps.at(feat->featid).insert({cam2uv.first,feat->timestamps.at(cam2uv.first)});
-                }
-            }
-        } else {
-            hist_feat_posinG.insert({feat->featid,p_FinG});
-            hist_feat_uvs.insert({feat->featid,feat->uvs});
-            hist_feat_uvs_norm.insert({feat->featid,feat->uvs_norm});
-            hist_feat_timestamps.insert({feat->featid,feat->timestamps});
-        }
-    }
-    // If we have reached our max window size record the oldest clone
-    // This clone is expected to be marginalized from the state
-    if ((int) state->_clones_IMU.size() > state->_options.max_clone_size) {
-        hist_last_marginalized_time = state->margtimestep();
-        assert(hist_last_marginalized_time != INFINITY);
-        Eigen::Matrix<double,7,1> imustate_inG = Eigen::Matrix<double,7,1>::Zero();
-        imustate_inG.block(0,0,4,1) = state->_clones_IMU.at(hist_last_marginalized_time)->quat();
-        imustate_inG.block(4,0,3,1) = state->_clones_IMU.at(hist_last_marginalized_time)->pos();
-        hist_stateinG.insert({hist_last_marginalized_time, imustate_inG});
-    }
-    //===================================================================================
-    //===================================================================================
-    //===================================================================================
-
+    // Collect all slam features into single vector
+    std::vector<Feature*> features_used_in_update = featsup_MSCKF;
+    features_used_in_update.insert(features_used_in_update.end(), feats_slam_UPDATE.begin(), feats_slam_UPDATE.end());
+    features_used_in_update.insert(features_used_in_update.end(), feats_slam_DELAYED.begin(), feats_slam_DELAYED.end());
+    update_keyframe_historical_information(features_used_in_update);
 
 
     // Save all the MSCKF features used in the update
@@ -710,10 +640,91 @@ void VioManager::do_feature_propagate_update(double timestamp) {
 }
 
 
+void VioManager::update_keyframe_historical_information(const std::vector<Feature*> &features) {
 
 
+    // Loop through all features that have been used in the last update
+    // We want to record their historical measurements and estimates for later use
+    for(const auto &feat : features) {
+
+        // Get position of feature in the global frame of reference
+        Eigen::Vector3d p_FinG = feat->p_FinG;
+
+        // If it is a slam feature, then get its best guess from the state
+        if(state->_features_SLAM.find(feat->featid)!=state->_features_SLAM.end()) {
+            p_FinG = state->_features_SLAM.at(feat->featid)->get_xyz(false);
+        }
+
+        // Push back any new measurements if we have them
+        // Ensure that if the feature is already added, then just append the new measurements
+        if(hist_feat_posinG.find(feat->featid)!=hist_feat_posinG.end()) {
+            hist_feat_posinG.at(feat->featid) = p_FinG;
+            for(const auto &cam2uv : feat->uvs) {
+                if(hist_feat_uvs.at(feat->featid).find(cam2uv.first)!=hist_feat_uvs.at(feat->featid).end()) {
+                    hist_feat_uvs.at(feat->featid).at(cam2uv.first).insert(hist_feat_uvs.at(feat->featid).at(cam2uv.first).end(), cam2uv.second.begin(), cam2uv.second.end());
+                    hist_feat_uvs_norm.at(feat->featid).at(cam2uv.first).insert(hist_feat_uvs_norm.at(feat->featid).at(cam2uv.first).end(), feat->uvs_norm.at(cam2uv.first).begin(), feat->uvs_norm.at(cam2uv.first).end());
+                    hist_feat_timestamps.at(feat->featid).at(cam2uv.first).insert(hist_feat_timestamps.at(feat->featid).at(cam2uv.first).end(), feat->timestamps.at(cam2uv.first).begin(), feat->timestamps.at(cam2uv.first).end());
+                } else {
+                    hist_feat_uvs.at(feat->featid).insert(cam2uv);
+                    hist_feat_uvs_norm.at(feat->featid).insert({cam2uv.first,feat->uvs_norm.at(cam2uv.first)});
+                    hist_feat_timestamps.at(feat->featid).insert({cam2uv.first,feat->timestamps.at(cam2uv.first)});
+                }
+            }
+        } else {
+            hist_feat_posinG.insert({feat->featid,p_FinG});
+            hist_feat_uvs.insert({feat->featid,feat->uvs});
+            hist_feat_uvs_norm.insert({feat->featid,feat->uvs_norm});
+            hist_feat_timestamps.insert({feat->featid,feat->timestamps});
+        }
+    }
 
 
+    // Go through all our old historical vectors and find if any features should be removed
+    // In this case we know that if we have no use for features that only have info older then the last marg time
+    std::vector<size_t> ids_to_remove;
+    for(const auto &id2feat : hist_feat_timestamps) {
+        bool all_older = true;
+        for(const auto &cam2time : id2feat.second) {
+            for(const auto &time : cam2time.second) {
+                if(time >= hist_last_marginalized_time) {
+                    all_older = false;
+                    break;
+                }
+            }
+            if(!all_older) break;
+        }
+        if(all_older) {
+            ids_to_remove.push_back(id2feat.first);
+        }
+    }
+
+    // Remove those features!
+    for(const auto &id : ids_to_remove) {
+        hist_feat_posinG.erase(id);
+        hist_feat_uvs.erase(id);
+        hist_feat_uvs_norm.erase(id);
+        hist_feat_timestamps.erase(id);
+    }
+
+    // Remove any historical states older then the marg time
+    auto it0 = hist_stateinG.begin();
+    while(it0 != hist_stateinG.end()) {
+        if(it0->first < hist_last_marginalized_time) it0 = hist_stateinG.erase(it0);
+        else it0++;
+    }
+    
+    // If we have reached our max window size record the oldest clone
+    // This clone is expected to be marginalized from the state
+    if ((int) state->_clones_IMU.size() > state->_options.max_clone_size) {
+        hist_last_marginalized_time = state->margtimestep();
+        assert(hist_last_marginalized_time != INFINITY);
+        Eigen::Matrix<double,7,1> imustate_inG = Eigen::Matrix<double,7,1>::Zero();
+        imustate_inG.block(0,0,4,1) = state->_clones_IMU.at(hist_last_marginalized_time)->quat();
+        imustate_inG.block(4,0,3,1) = state->_clones_IMU.at(hist_last_marginalized_time)->pos();
+        hist_stateinG.insert({hist_last_marginalized_time, imustate_inG});
+    }
+
+}
 
 
 

--- a/ov_msckf/src/core/VioManager.h
+++ b/ov_msckf/src/core/VioManager.h
@@ -216,6 +216,18 @@ namespace ov_msckf {
         }
 
 
+        // TODO: remove these and move to a "history" stucture?
+        // TODO: should figure out a better way to store these
+        double hist_last_marginalized_time = -1;
+        std::map<double,Eigen::Matrix<double,7,1>> hist_stateinG;
+        std::map<size_t,Eigen::Vector3d> hist_feat_posinG;
+        std::unordered_map<size_t, std::unordered_map<size_t, std::vector<Eigen::VectorXf>>> hist_feat_uvs;
+        std::unordered_map<size_t, std::unordered_map<size_t, std::vector<Eigen::VectorXf>>> hist_feat_uvs_norm;
+        std::unordered_map<size_t, std::unordered_map<size_t, std::vector<double>>> hist_feat_timestamps;
+
+
+
+
 
     protected:
 

--- a/ov_msckf/src/state/StateHelper.h
+++ b/ov_msckf/src/state/StateHelper.h
@@ -215,6 +215,7 @@ namespace ov_msckf {
         static void marginalize_old_clone(State *state) {
             if ((int) state->_clones_IMU.size() > state->_options.max_clone_size) {
                 double marginal_time = state->margtimestep();
+                assert(marginal_time != INFINITY);
                 StateHelper::marginalize(state, state->_clones_IMU.at(marginal_time));
                 // Note that the marginalizer should have already deleted the clone
                 // Thus we just need to remove the pointer to it from our state


### PR DESCRIPTION
## Key Changes:
- Introduce saving logic to allow for publishing of marginalized feature information
- Now all triangulated features are temporarily stored till they are lost completely
- When the last clone is marginalized from the sliding window, all features seen from that time are published. Their best 3d position in the global and uv measurement information is published.
- An example repository [ov_secondary](https://github.com/rpng/ov_secondary) has been created to show how one could leverage this information to have a secondary pose graph bound drift through relative pose loop closures.


## Secondary Pose Graph (see  [ov_secondary](https://github.com/rpng/ov_secondary)):
- This example is based on the [VINS-Fusion](https://github.com/HKUST-Aerial-Robotics/VINS-Fusion) secondary local pose graph thread.
- The code has been modified to allow for subscribing to intrinsic camera parameter topics
- Additional parameters have been exposed with some example results.
- Please see the [ov_secondary](https://github.com/rpng/ov_secondary) repository readme for more details on this.

## Discussion of Impact of Pose Graph:
While the secondary pose graph works well in some cases, in many other cases it fails to improve performance or even hurt it. For example on the EurocMav dataset there isn't a clear winner in terms of ATE/RPE accuracy of the OpenVINS odometry poses being fed into the loop closure module and its published states. On these small room datasets, many loop closure candidates are rejected, and thus there are maybe 2-4 loop closures, with V1_02_medium dataset having none over the whole trajectory in most cases. Also to ensure there are enough points for PnP, the number of tracked features in ov_msckf needed to be increased to around 300.

![image](https://user-images.githubusercontent.com/2222562/82180992-a5685b80-98af-11ea-8b2b-a45c8b65762b.png)

On the other hand, there are cases where the loop closure clearly helps. For example, on a long dataset such as the corridor1 from the TUM-VI dataset the system running in monocular mode drifts towards the end of the dataset (blue). The loop closure (red) is able to correct this and ensure that the ending pose is correct relative to the start (the sensor system returns to the same location in the bottom left of this trajectory).

![image](https://user-images.githubusercontent.com/2222562/82180999-aa2d0f80-98af-11ea-8031-1dedfdf3785f.png)

Looking at some more quantitative results on the TUM-VI dataset, a few runs on the room datasets can clearly show the advantage of loop closure. These room datasets are limited to the same vicon room environment, and get very frequent loop closures due to this. From the below table, it is very clear that using the secondary loop closure thread in most cases has a clear performance gain as compared to the standard odometry.

![image](https://user-images.githubusercontent.com/2222562/82181008-b022f080-98af-11ea-9e71-0e39718d44d1.png)



