### PR TITLE
Use smart pointers instead of raw pointers

### DIFF
--- a/ov_core/src/track/TrackBase.h
+++ b/ov_core/src/track/TrackBase.h
@@ -87,6 +87,8 @@ namespace ov_core {
             currid = (size_t) numaruco + 1;
         }
 
+        virtual ~TrackBase() { }
+
 
         /**
          * @brief Given a the camera intrinsic values, this will set what we should normalize points with.

--- a/ov_msckf/src/core/VioManager.h
+++ b/ov_msckf/src/core/VioManager.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <algorithm>
 #include <fstream>
+#include <memory>
 #include <Eigen/StdVector>
 #include <boost/filesystem.hpp>
 
@@ -147,22 +148,22 @@ namespace ov_msckf {
 
         /// Accessor to get the current state
         State* get_state() {
-            return state;
+            return state.get();
         }
 
         /// Accessor to get the current propagator
         Propagator* get_propagator() {
-            return propagator;
+            return propagator.get();
         }
 
         /// Get feature tracker
         TrackBase* get_track_feat() {
-            return trackFEATS;
+            return trackFEATS.get();
         }
 
         /// Get aruco feature tracker
         TrackBase* get_track_aruco() {
-            return trackARUCO;
+            return trackARUCO.get();
         }
 
         /// Returns 3d features used in the last update in global frame
@@ -286,31 +287,31 @@ namespace ov_msckf {
         VioManagerOptions params;
 
         /// Our master state object :D
-        State* state;
+		std::unique_ptr<State> state;
 
         /// Propagator of our state
-        Propagator* propagator;
+		std::unique_ptr<Propagator> propagator;
 
         /// Our sparse feature tracker (klt or descriptor)
-        TrackBase* trackFEATS = nullptr;
+        std::unique_ptr<TrackBase> trackFEATS;
 
         /// Our aruoc tracker
-        TrackBase* trackARUCO = nullptr;
+        std::unique_ptr<TrackBase> trackARUCO;
 
         /// State initializer
-        InertialInitializer* initializer;
+        std::unique_ptr<InertialInitializer> initializer;
 
         /// Boolean if we are initialized or not
         bool is_initialized_vio = false;
 
         /// Our MSCKF feature updater
-        UpdaterMSCKF* updaterMSCKF;
+        std::unique_ptr<UpdaterMSCKF> updaterMSCKF;
 
         /// Our MSCKF feature updater
-        UpdaterSLAM* updaterSLAM;
+        std::unique_ptr<UpdaterSLAM> updaterSLAM;
 
         /// Our aruoc tracker
-        UpdaterZeroVelocity* updaterZUPT = nullptr;
+        std::unique_ptr<UpdaterZeroVelocity> updaterZUPT;
 
         /// Good features that where used in the last update
         std::vector<Eigen::Vector3d> good_features_MSCKF;


### PR DESCRIPTION
- Before this, `VioManager` leaked memory, because it would hold pointers that it does not deallocate when it is deallocated.
- I fixed this by making `VioManager` hold "smart pointers", so the memory will automatically be deallocated when the `VioManager` gets deleted (as opposed to writing a destructor and copy-constructor).
  - However, this does make `VioManager` uncopyable, but I believe that before this, copies of `VioManager` were logically incorrect, because the old code would make shallow copies of the internal member pointers.
- Furthermore, `TrackBase` needs to have a *virtual* destructor to deallocate properly.