### PR TITLE
Update cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.3)
 
 add_subdirectory(ov_core)
-add_subdirectory(ov_eval)
 add_subdirectory(ov_msckf)
+
+# Optionally build the eval module, might not needed if building for a drone/robotic system
+option(BUILD_OV_EVAL "Enable or disable building of ov_eval" ON)
+if (BUILD_OV_EVAL)
+	add_subdirectory(ov_eval)
+endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.3)
 
+# Project name
+project(open_vins)
+
 add_subdirectory(ov_core)
 add_subdirectory(ov_msckf)
 

--- a/ov_core/CMakeLists.txt
+++ b/ov_core/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 
+include(GNUInstallDirs)
+
 # Project name
 project(ov_core)
 
@@ -95,9 +97,9 @@ add_library(ov_core_lib SHARED
 target_link_libraries(ov_core_lib ${thirdparty_libraries})
 target_include_directories(ov_core_lib PUBLIC src)
 install(TARGETS ov_core_lib
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 ##################################################
@@ -111,9 +113,9 @@ endif()
 add_executable(test_webcam src/test_webcam.cpp)
 target_link_libraries(test_webcam ov_core_lib ${thirdparty_libraries})
 install(TARGETS test_webcam
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 

--- a/ov_core/CMakeLists.txt
+++ b/ov_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.3)
 
 # Project name
 project(ov_core)

--- a/ov_core/CMakeLists.txt
+++ b/ov_core/CMakeLists.txt
@@ -94,7 +94,11 @@ add_library(ov_core_lib SHARED
 )
 target_link_libraries(ov_core_lib ${thirdparty_libraries})
 target_include_directories(ov_core_lib PUBLIC src)
-
+install(TARGETS ov_core_lib
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 ##################################################
 # Make binary files!
@@ -106,5 +110,10 @@ endif()
 
 add_executable(test_webcam src/test_webcam.cpp)
 target_link_libraries(test_webcam ov_core_lib ${thirdparty_libraries})
+install(TARGETS test_webcam
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 

--- a/ov_data/CMakeLists.txt
+++ b/ov_data/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.3)
 
 # Project name
 project(ov_data)

--- a/ov_eval/CMakeLists.txt
+++ b/ov_eval/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.3)
 
 # Project name
 project(ov_eval)

--- a/ov_eval/CMakeLists.txt
+++ b/ov_eval/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 
+include(GNUInstallDirs)
+
 # Project name
 project(ov_eval)
 
@@ -88,9 +90,9 @@ add_library(ov_eval_lib SHARED
 )
 target_link_libraries(ov_eval_lib ${thirdparty_libraries})
 install(TARGETS ov_eval_lib
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 
@@ -111,73 +113,73 @@ endif()
 add_executable(format_converter src/format_converter.cpp)
 target_link_libraries(format_converter ov_eval_lib ${thirdparty_libraries})
 install(TARGETS format_converter
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(error_comparison src/error_comparison.cpp)
 target_link_libraries(error_comparison ov_eval_lib ${thirdparty_libraries})
 install(TARGETS error_comparison
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(error_dataset src/error_dataset.cpp)
 target_link_libraries(error_dataset ov_eval_lib ${thirdparty_libraries})
 install(TARGETS error_dataset
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(error_singlerun src/error_singlerun.cpp)
 target_link_libraries(error_singlerun ov_eval_lib ${thirdparty_libraries})
 install(TARGETS error_singlerun
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(error_simulation src/error_simulation.cpp)
 target_link_libraries(error_simulation ov_eval_lib ${thirdparty_libraries})
 install(TARGETS error_simulation
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(timing_flamegraph src/timing_flamegraph.cpp)
 target_link_libraries(timing_flamegraph ov_eval_lib ${thirdparty_libraries})
 install(TARGETS timing_flamegraph
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(timing_comparison src/timing_comparison.cpp)
 target_link_libraries(timing_comparison ov_eval_lib ${thirdparty_libraries})
 install(TARGETS timing_comparison
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(timing_percentages src/timing_percentages.cpp)
 target_link_libraries(timing_percentages ov_eval_lib ${thirdparty_libraries})
 install(TARGETS timing_percentages
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(plot_trajectories src/plot_trajectories.cpp)
 target_link_libraries(plot_trajectories ov_eval_lib ${thirdparty_libraries})
 install(TARGETS plot_trajectories
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 

--- a/ov_eval/CMakeLists.txt
+++ b/ov_eval/CMakeLists.txt
@@ -78,7 +78,7 @@ list(APPEND thirdparty_libraries
 ##################################################
 # Make the core library
 ##################################################
-add_library(ov_eval_lib
+add_library(ov_eval_lib SHARED
         src/dummy.cpp
         src/alignment/AlignTrajectory.cpp
         src/alignment/AlignUtils.cpp
@@ -87,6 +87,11 @@ add_library(ov_eval_lib
         src/utils/Loader.cpp
 )
 target_link_libraries(ov_eval_lib ${thirdparty_libraries})
+install(TARGETS ov_eval_lib
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 
 ##################################################
@@ -95,42 +100,85 @@ target_link_libraries(ov_eval_lib ${thirdparty_libraries})
 
 
 if (catkin_FOUND AND ENABLE_CATKIN_ROS)
-
     add_executable(pose_to_file src/pose_to_file.cpp)
     target_link_libraries(pose_to_file ov_eval_lib ${thirdparty_libraries})
 
     add_executable(live_align_trajectory src/live_align_trajectory.cpp)
     target_link_libraries(live_align_trajectory ov_eval_lib ${thirdparty_libraries})
-
 endif()
 
 
 add_executable(format_converter src/format_converter.cpp)
 target_link_libraries(format_converter ov_eval_lib ${thirdparty_libraries})
+install(TARGETS format_converter
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 add_executable(error_comparison src/error_comparison.cpp)
 target_link_libraries(error_comparison ov_eval_lib ${thirdparty_libraries})
+install(TARGETS error_comparison
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 add_executable(error_dataset src/error_dataset.cpp)
 target_link_libraries(error_dataset ov_eval_lib ${thirdparty_libraries})
+install(TARGETS error_dataset
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 add_executable(error_singlerun src/error_singlerun.cpp)
 target_link_libraries(error_singlerun ov_eval_lib ${thirdparty_libraries})
+install(TARGETS error_singlerun
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 add_executable(error_simulation src/error_simulation.cpp)
 target_link_libraries(error_simulation ov_eval_lib ${thirdparty_libraries})
+install(TARGETS error_simulation
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 add_executable(timing_flamegraph src/timing_flamegraph.cpp)
 target_link_libraries(timing_flamegraph ov_eval_lib ${thirdparty_libraries})
+install(TARGETS timing_flamegraph
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 add_executable(timing_comparison src/timing_comparison.cpp)
 target_link_libraries(timing_comparison ov_eval_lib ${thirdparty_libraries})
+install(TARGETS timing_comparison
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 add_executable(timing_percentages src/timing_percentages.cpp)
 target_link_libraries(timing_percentages ov_eval_lib ${thirdparty_libraries})
+install(TARGETS timing_percentages
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 add_executable(plot_trajectories src/plot_trajectories.cpp)
 target_link_libraries(plot_trajectories ov_eval_lib ${thirdparty_libraries})
+install(TARGETS plot_trajectories
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 
 ##################################################

--- a/ov_msckf/CMakeLists.txt
+++ b/ov_msckf/CMakeLists.txt
@@ -109,6 +109,12 @@ endif()
 add_library(ov_msckf_lib SHARED ${library_source_files})
 target_link_libraries(ov_msckf_lib ${thirdparty_libraries})
 target_include_directories(ov_msckf_lib PUBLIC src)
+install(TARGETS ov_msckf_lib
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
+
 
 
 ##################################################
@@ -137,8 +143,18 @@ endif()
 
 add_executable(test_sim_meas src/test_sim_meas.cpp)
 target_link_libraries(test_sim_meas ov_msckf_lib ${thirdparty_libraries})
+install(TARGETS test_sim_meas
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 add_executable(test_sim_repeat src/test_sim_repeat.cpp)
 target_link_libraries(test_sim_repeat ov_msckf_lib ${thirdparty_libraries})
+install(TARGETS test_sim_repeat
+        LIBRARY         DESTINATION /usr/lib
+        RUNTIME         DESTINATION /usr/bin
+        PUBLIC_HEADER   DESTINATION /usr/include
+)
 
 

--- a/ov_msckf/CMakeLists.txt
+++ b/ov_msckf/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 
+include(GNUInstallDirs)
+
 # Project name
 project(ov_msckf)
 
@@ -110,9 +112,9 @@ add_library(ov_msckf_lib SHARED ${library_source_files})
 target_link_libraries(ov_msckf_lib ${thirdparty_libraries})
 target_include_directories(ov_msckf_lib PUBLIC src)
 install(TARGETS ov_msckf_lib
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 
@@ -144,17 +146,17 @@ endif()
 add_executable(test_sim_meas src/test_sim_meas.cpp)
 target_link_libraries(test_sim_meas ov_msckf_lib ${thirdparty_libraries})
 install(TARGETS test_sim_meas
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(test_sim_repeat src/test_sim_repeat.cpp)
 target_link_libraries(test_sim_repeat ov_msckf_lib ${thirdparty_libraries})
 install(TARGETS test_sim_repeat
-        LIBRARY         DESTINATION /usr/lib
-        RUNTIME         DESTINATION /usr/bin
-        PUBLIC_HEADER   DESTINATION /usr/include
+        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 

--- a/ov_msckf/CMakeLists.txt
+++ b/ov_msckf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.3)
 
 # Project name
 project(ov_msckf)


### PR DESCRIPTION
Hi!  Im working on integrating open_vins into a flying drone and needed to make some changes to the cmake files in order to get the code to compile and deploy onto a drone.  I figured that these changes might be useful for others who may be looking to integrate open_vins onto various hardware platforms (like a drone or car).  Please let me know if these seem acceptable (this is my first time contributing to an open source project like this)

**Whats in this pull request:**
1. Bumping the cmake version
2. Adding install targets to cmake 
3. Changing ov_eval_lib to a shared library
4. Make building  ov_eval optional

Most (if not all) of the changes in this pull request are for when building without catkin (aka no ROS).  

**Bumping the cmake version**
2.8.8 is an old cmake version and it has trouble compiling in projects that use a 3.x version of cmake.  Bumping the cmake version to a 3.x version makes it easier to compile open_vins into other projects that also use cmake 3 versions.  I chose 3.3 since it is a low number cmake versions and thus should still work on most systems as most systems will have a cmake version higher than 3.3.

**Adding install targets to cmake**
When compiling and deploying open_vins for use on drones (without ROS) we need a way to install the shared library (.so files).  Usually this is done with `make install` and therefore we need to specify what targets should be installed.  I added install calls to the make file to specify those install targets as well as default locations to install those targets (the standard /usr/lib, /usr/include, ext).

**Changing ov_eval_lib to a shared library** 
I noticed that "ov_eval_lib" was compiling as a static library when all the other libraries are compiling as a shared library.  the ov_eval project also has a lot of executable targets and so I think there would be some benefit to making it a shared library

**Make building  ov_eval optional**
When compiling open_vins for deployment on a drone, ov_eval is not needed.  I added a flag to allow the developer to disable compilation of ov_eval (just like you can disable ROS) so that only ov_core and ov_msckf are compiled and installed.


