### PR TITLE
fix bugs (build pdf reference manual)

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1642,7 +1642,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         =
+EXTRA_PACKAGES         = {amsmath,amssymb,stmaryrd,xcolor}
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first
@@ -1739,7 +1739,7 @@ LATEX_SOURCE_CODE      = NO
 # The default value is: plain.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_BIB_STYLE        = ieeetr
+LATEX_BIB_STYLE        = plaainnat
 
 # If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
 # page will contain the date and time when the page was generated. Setting this

--- a/docs/bib/extra.bib
+++ b/docs/bib/extra.bib
@@ -97,7 +97,7 @@
     author = {Kay, Steven M},
     year = {1993},
     publisher = {Prentice Hall PTR},
-    url = {http://users.isr.ist.utl.pt/~pjcro/temp/Fundamentals%20Of%20Statistical%20Signal%20Processing%2D%2DEstimation%20Theory-Kay.pdf},
+    url = {http://users.isr.ist.utl.pt/~pjcro/temp/Fundamentals\%20Of\%20Statistical\%20Signal\%20Processing\%2D\%2DEstimation\%20Theory-Kay.pdf},
 }
 
 @inproceedings{Mourikis2007ICRA,


### PR DESCRIPTION
There are some errors when I build pdf reference manual:

![Screenshot from 2021-12-23 15-57-30](https://user-images.githubusercontent.com/20852068/147207795-131ec807-06f5-4b36-80a3-3884c2123615.png)

![Screenshot from 2021-12-23 16-02-54](https://user-images.githubusercontent.com/20852068/147208391-e85356fe-5382-4591-8213-a14aa8fd899b.png)

My system:

- Ubuntu 18.04
- Doxygen: 1.8.13
- pdfTeX 3.14159265-2.6-1.40.18 (TeX Live 2017/Debian)

So I change the Doxyfile and bib file to fix these errors:

1. add EXTRA_PACKAGES in Doxyfile
2. escape '%' in bib file
