### PR TITLE
support building of pdf reference manual

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1642,7 +1642,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         =
+EXTRA_PACKAGES         = {amsmath,amssymb,stmaryrd,xcolor}
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first
@@ -1739,7 +1739,7 @@ LATEX_SOURCE_CODE      = NO
 # The default value is: plain.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_BIB_STYLE        = ieeetr
+LATEX_BIB_STYLE        = plainnat
 
 # If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
 # page will contain the date and time when the page was generated. Setting this

--- a/Doxyfile
+++ b/Doxyfile
@@ -228,7 +228,23 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                =
+## Add nice shorthand for code comments
+## https://mcss.mosra.cz/documentation/doxygen/#code-highlighting
+ALIASES += \
+    "cb{1}=@code{\1}" \
+    "ce=@endcode" \
+    "cpp=@code{.cpp}" \
+    "cmake=@code{.cmake}" \
+    "m_div{1}=@xmlonly<mcss:div xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:class=\"\1\">@endxmlonly" \
+    "m_enddiv=@xmlonly</mcss:div>@endxmlonly" \
+    "m_span{1}=@xmlonly<mcss:span xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:class=\"\1\">@endxmlonly" \
+    "m_endspan=@xmlonly</mcss:span>@endxmlonly" \
+    "m_class{1}=@xmlonly<mcss:class xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:class=\"\1\" />@endxmlonly" \
+    "m_footernavigation=@xmlonly<mcss:footernavigation xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" />@endxmlonly" \
+    "m_examplenavigation{2}=@xmlonly<mcss:examplenavigation xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:page=\"\1\" mcss:prefix=\"\2\" />@endxmlonly" \
+    "m_keywords{1}=@xmlonly<mcss:search xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:keywords=\"\1\" />@endxmlonly" \
+    "m_keyword{3}=@xmlonly<mcss:search xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:keyword=\"\1\" mcss:title=\"\2\" mcss:suffix-length=\"\3\" />@endxmlonly" \
+    "m_enum_values_as_keywords=@xmlonly<mcss:search xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:enum-values-as-keywords=\"true\" />@endxmlonly"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"
@@ -416,13 +432,13 @@ LOOKUP_CACHE_SIZE      = 0
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = YES
+EXTRACT_ALL            = NO
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = YES
+EXTRACT_PRIVATE        = NO
 
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.
@@ -604,19 +620,19 @@ STRICT_PROTO_MATCHING  = NO
 # list. This list is created by putting \todo commands in the documentation.
 # The default value is: YES.
 
-GENERATE_TODOLIST      = YES
+GENERATE_TODOLIST      = NO
 
 # The GENERATE_TESTLIST tag can be used to enable (YES) or disable (NO) the test
 # list. This list is created by putting \test commands in the documentation.
 # The default value is: YES.
 
-GENERATE_TESTLIST      = YES
+GENERATE_TESTLIST      = NO
 
 # The GENERATE_BUGLIST tag can be used to enable (YES) or disable (NO) the bug
 # list. This list is created by putting \bug commands in the documentation.
 # The default value is: YES.
 
-GENERATE_BUGLIST       = YES
+GENERATE_BUGLIST       = NO
 
 # The GENERATE_DEPRECATEDLIST tag can be used to enable (YES) or disable (NO)
 # the deprecated list. This list is created by putting \deprecated commands in
@@ -647,14 +663,14 @@ MAX_INITIALIZER_LINES  = 30
 # list will mention the files that were used to generate the documentation.
 # The default value is: YES.
 
-SHOW_USED_FILES        = YES
+SHOW_USED_FILES        = NO
 
 # Set the SHOW_FILES tag to NO to disable the generation of the Files page. This
 # will remove the Files entry from the Quick Index and from the Folder Tree View
 # (if specified).
 # The default value is: YES.
 
-SHOW_FILES             = YES
+SHOW_FILES             = NO
 
 # Set the SHOW_NAMESPACES tag to NO to disable the generation of the Namespaces
 # page. This will remove the Namespaces entry from the Quick Index and from the
@@ -811,7 +827,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ov_core/src/utils/CLI11.hpp
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -827,7 +843,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */doxygen_generated/* */catkin_generated/* */cmake-build-debug/* */plot/* .github  .idea
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -864,7 +880,8 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = docs/ \
+IMAGE_PATH             = ./ \
+                         docs/ \
                          docs/img/ \
                          docs/youtube/
 
@@ -1630,7 +1647,7 @@ COMPACT_LATEX          = NO
 # The default value is: a4.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-PAPER_TYPE             = a4
+PAPER_TYPE             = letter
 
 # The EXTRA_PACKAGES tag can be used to specify one or more LaTeX package names
 # that should be included in the LaTeX output. The package can be specified just
@@ -1642,7 +1659,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         = {amsmath,amssymb,stmaryrd,xcolor}
+EXTRA_PACKAGES         = amsmath,amssymb,stmaryrd,xcolor
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first
@@ -2171,7 +2188,7 @@ DOT_FONTPATH           =
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CLASS_GRAPH            = YES
+CLASS_GRAPH            = NO
 
 # If the COLLABORATION_GRAPH tag is set to YES then doxygen will generate a
 # graph for each documented class showing the direct and indirect implementation
@@ -2180,14 +2197,14 @@ CLASS_GRAPH            = YES
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-COLLABORATION_GRAPH    = YES
+COLLABORATION_GRAPH    = NO
 
 # If the GROUP_GRAPHS tag is set to YES then doxygen will generate a graph for
 # groups, showing the direct groups dependencies.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-GROUP_GRAPHS           = YES
+GROUP_GRAPHS           = NO
 
 # If the UML_LOOK tag is set to YES, doxygen will generate inheritance and
 # collaboration diagrams in a style similar to the OMG's Unified Modeling
@@ -2225,7 +2242,7 @@ TEMPLATE_RELATIONS     = NO
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-INCLUDE_GRAPH          = YES
+INCLUDE_GRAPH          = NO
 
 # If the INCLUDED_BY_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are
 # set to YES then doxygen will generate a graph for each documented file showing
@@ -2234,7 +2251,7 @@ INCLUDE_GRAPH          = YES
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-INCLUDED_BY_GRAPH      = YES
+INCLUDED_BY_GRAPH      = NO
 
 # If the CALL_GRAPH tag is set to YES then doxygen will generate a call
 # dependency graph for every global function or class method.
@@ -2265,7 +2282,7 @@ CALLER_GRAPH           = NO
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-GRAPHICAL_HIERARCHY    = YES
+GRAPHICAL_HIERARCHY    = NO
 
 # If the DIRECTORY_GRAPH tag is set to YES then doxygen will show the
 # dependencies a directory has on other directories in a graphical way. The
@@ -2274,7 +2291,7 @@ GRAPHICAL_HIERARCHY    = YES
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DIRECTORY_GRAPH        = YES
+DIRECTORY_GRAPH        = NO
 
 # The DOT_IMAGE_FORMAT tag can be used to set the image format of the images
 # generated by dot. For an explanation of the image formats see the section

--- a/Doxyfile-mcss
+++ b/Doxyfile-mcss
@@ -9,28 +9,9 @@ HTML_EXTRA_STYLESHEET = \
     docs/css/custom.css
 
 
-
 ## No need to expose to-do list or bug list in public docs.
 GENERATE_TODOLIST      = NO
 GENERATE_BUGLIST       = NO
-
-## Add nice shorthand for code comments
-## https://mcss.mosra.cz/documentation/doxygen/#code-highlighting
-ALIASES += \
-    "cb{1}=@code{\1}" \
-    "ce=@endcode" \
-    "cpp=@code{.cpp}" \
-    "cmake=@code{.cmake}" \
-    "m_div{1}=@xmlonly<mcss:div xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:class=\"\1\">@endxmlonly" \
-    "m_enddiv=@xmlonly</mcss:div>@endxmlonly" \
-    "m_span{1}=@xmlonly<mcss:span xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:class=\"\1\">@endxmlonly" \
-    "m_endspan=@xmlonly</mcss:span>@endxmlonly" \
-    "m_class{1}=@xmlonly<mcss:class xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:class=\"\1\" />@endxmlonly" \
-    "m_footernavigation=@xmlonly<mcss:footernavigation xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" />@endxmlonly" \
-    "m_examplenavigation{2}=@xmlonly<mcss:examplenavigation xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:page=\"\1\" mcss:prefix=\"\2\" />@endxmlonly" \
-    "m_keywords{1}=@xmlonly<mcss:search xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:keywords=\"\1\" />@endxmlonly" \
-    "m_keyword{3}=@xmlonly<mcss:search xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:keyword=\"\1\" mcss:title=\"\2\" mcss:suffix-length=\"\3\" />@endxmlonly" \
-    "m_enum_values_as_keywords=@xmlonly<mcss:search xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:enum-values-as-keywords=\"true\" />@endxmlonly"
 
 ##! M_THEME_COLOR           = #2f73a3
 ##! M_FAVICON               = docs/img/favicon-light.png

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -115,14 +115,30 @@ details on what the system supports.
 
 ## Demo Videos
 
-[![](docs/youtube/KCX51GvYGss.jpg)](http://www.youtube.com/watch?v=KCX51GvYGss "OpenVINS - EuRoC MAV Vicon Rooms Flyby")
-[![](docs/youtube/Lc7VQHngSuQ.jpg)](http://www.youtube.com/watch?v=Lc7VQHngSuQ "OpenVINS - TUM VI Datasets Flyby")
-[![](docs/youtube/vaia7iPaRW8.jpg)](http://www.youtube.com/watch?v=vaia7iPaRW8 "OpenVINS - UZH-FPV Drone Racing Dataset Flyby")
-[![](docs/youtube/MCzTF9ye2zw.jpg)](http://www.youtube.com/watch?v=MCzTF9ye2zw "OpenVINS - KAIST Urban 39 Dataset Demonstration")
+<a href="http://www.youtube.com/watch?v=KCX51GvYGss">
+   <img src="https://raw.githubusercontent.com/rpng/open_vins/master/docs/youtube/KCX51GvYGss.jpg" width="120" height="90" />
+</a>
+<a href="http://www.youtube.com/watch?v=Lc7VQHngSuQ">
+   <img src="https://raw.githubusercontent.com/rpng/open_vins/master/docs/youtube/Lc7VQHngSuQ.jpg" width="120" height="90" />
+</a>
+<a href="http://www.youtube.com/watch?v=vaia7iPaRW8">
+   <img src="https://raw.githubusercontent.com/rpng/open_vins/master/docs/youtube/vaia7iPaRW8.jpg" width="120" height="90" />
+</a>
+<a href="http://www.youtube.com/watch?v=MCzTF9ye2zw">
+   <img src="https://raw.githubusercontent.com/rpng/open_vins/master/docs/youtube/MCzTF9ye2zw.jpg"  width="120" height="90"/>
+</a>
+<br/>
 
-[![](docs/youtube/187AXuuGNNw.jpg)](http://www.youtube.com/watch?v=187AXuuGNNw "OpenVINS - EuRoC MAV Vicon Rooms Demonstration")
-[![](docs/youtube/oUoLlrFryk0.jpg)](http://www.youtube.com/watch?v=oUoLlrFryk0 "OpenVINS - TUM VI Datasets Demostration")
-[![](docs/youtube/ExPIGwORm4E.jpg)](http://www.youtube.com/watch?v=ExPIGwORm4E "OpenVINS - UZH-FPV Drone Racing Dataset Demonstration")
+<a href="http://www.youtube.com/watch?v=187AXuuGNNw">
+   <img src="https://raw.githubusercontent.com/rpng/open_vins/master/docs/youtube/187AXuuGNNw.jpg" width="120" height="90" />
+</a>
+<a href="http://www.youtube.com/watch?v=oUoLlrFryk0">
+   <img src="https://raw.githubusercontent.com/rpng/open_vins/master/docs/youtube/oUoLlrFryk0.jpg" width="120" height="90" />
+</a>
+<a href="http://www.youtube.com/watch?v=ExPIGwORm4E">
+   <img src="https://raw.githubusercontent.com/rpng/open_vins/master/docs/youtube/ExPIGwORm4E.jpg" width="120" height="90" />
+</a>
+
 
 ## Credit / Licensing
 

--- a/docs/bib/extra.bib
+++ b/docs/bib/extra.bib
@@ -97,7 +97,7 @@
     author = {Kay, Steven M},
     year = {1993},
     publisher = {Prentice Hall PTR},
-    url = {http://users.isr.ist.utl.pt/~pjcro/temp/Fundamentals%20Of%20Statistical%20Signal%20Processing%2D%2DEstimation%20Theory-Kay.pdf},
+    url = {http://users.isr.ist.utl.pt/~pjcro/temp/Fundamentals\%20Of\%20Statistical\%20Signal\%20Processing\%2D\%2DEstimation\%20Theory-Kay.pdf},
 }
 
 @inproceedings{Mourikis2007ICRA,

--- a/docs/dev-docs.dox
+++ b/docs/dev-docs.dox
@@ -77,6 +77,16 @@
 - Use the command line utility `iperender`  to convert into a svg
 - `iperender -svg -transparent file.ipe file.svg`
 
+@section developers-pdfmanual Building the PDF Reference Manual
 
-
+1. You will need to install doxygen and texlive
+    - `sudo apt-get update`
+    - `sudo apt-get install doxygen texlive-full`
+2. Go into the project folder and generate
+    - `cd PATHTO/open_vins`
+    - `doxygen`
+3. Go into the generated latex folder and build
+    - `cd open_vins/doxgen_generated/latex`
+    - `make`
+4. Open the PDF file `/open_vins/doxgen_generated/latex/refman.pdf` to view documentation
 */

--- a/docs/dev-docs.dox
+++ b/docs/dev-docs.dox
@@ -4,6 +4,24 @@
 @page dev-docs Documentation Guide
 
 
+@section developers-pdfmanual Building the Latex PDF Reference Manual
+
+1. You will need to install doxygen and texlive with all packages
+    - `sudo apt-get update`
+    - `sudo apt-get install doxygen texlive-full`
+    - You will likely need new version of [doxygen](https://stackoverflow.com/a/50986638/7718197) 1.9.4 to fix ghostscript errors
+2. Go into the project folder and generate latex files
+    - `cd open_vins/`
+    - `doxygen`
+    - This should run, and will stop if there are any latex errors
+    - On my Ubuntu 20.04 this installs version "2019.20200218"
+3. Generate a PDF from the latex files
+    - `cd doxgen_generated/latex/`
+    - `make`
+    - File should be called `refman.pdf`
+
+
+
 @section developers-addpage Adding a Website Page
 
 1. Add a `doc/pagename.dox` file, copy up-to-date license header.
@@ -16,7 +34,6 @@
 
 
 @section latex Math / Latex Equations
-
 
 - More details on how to format your documentation can be found here:
     - http://www.doxygen.nl/manual/formulas.html
@@ -77,16 +94,5 @@
 - Use the command line utility `iperender`  to convert into a svg
 - `iperender -svg -transparent file.ipe file.svg`
 
-@section developers-pdfmanual Building the PDF Reference Manual
 
-1. You will need to install doxygen and texlive
-    - `sudo apt-get update`
-    - `sudo apt-get install doxygen texlive-full`
-2. Go into the project folder and generate
-    - `cd PATHTO/open_vins`
-    - `doxygen`
-3. Go into the generated latex folder and build
-    - `cd open_vins/doxgen_generated/latex`
-    - `make`
-4. Open the PDF file `/open_vins/doxgen_generated/latex/refman.pdf` to view documentation
 */

--- a/ov_core/src/cpi/CpiBase.h
+++ b/ov_core/src/cpi/CpiBase.h
@@ -29,10 +29,6 @@
 #include "utils/quat_ops.h"
 #include <Eigen/Dense>
 
-/**
- * @namespace ov_core
- * @brief Core algorithms for Open VINS
- */
 namespace ov_core {
 
 /**

--- a/ov_core/src/dummy.cpp
+++ b/ov_core/src/dummy.cpp
@@ -21,6 +21,7 @@
 
 /**
  * @namespace ov_core
+ * @brief Core algorithms for OpenVINS
  *
  * This has the core algorithms that all projects within the OpenVINS ecosystem leverage.
  * The purpose is to allow for the reuse of code that could be shared between different localization systems (i.e. msckf-based, batch-based,
@@ -44,6 +45,7 @@ namespace ov_core {}
 
 /**
  * @namespace ov_type
+ * @brief Dynamic type system types
  *
  * Types leveraged by the EKF system for covariance management.
  * These types store where they are in the covariance along with their current estimate.

--- a/ov_eval/src/dummy.cpp
+++ b/ov_eval/src/dummy.cpp
@@ -21,6 +21,7 @@
 
 /**
  * @namespace ov_eval
+ * @brief Evaluation and recording utilities
  *
  * This project contains the key evaluation and research scripts for localization methods.
  * These come from the necessity of trying to quantify the accuracy of the estimated trajectory while

--- a/ov_init/src/dummy.cpp
+++ b/ov_init/src/dummy.cpp
@@ -21,6 +21,7 @@
 
 /**
  * @namespace ov_init
+ * @brief State initialization code
  *
  * Right now this contains static initialization code for a visual-inertial system.
  * It will wait for the platform to stationary, and then initialize its orientation in the gravity frame.

--- a/ov_msckf/src/dummy.cpp
+++ b/ov_msckf/src/dummy.cpp
@@ -21,6 +21,7 @@
 
 /**
  * @namespace ov_msckf
+ * @brief Extended Kalman Filter estimator
  *
  * This is an implementation of a [Multi-State Constraint Kalman Filter (MSCKF)](https://ieeexplore.ieee.org/document/4209642) @cite
  * Mourikis2007ICRA which leverages inertial and visual feature information. We want to stress that this is **not** a "vanilla"


### PR DESCRIPTION
There are some errors when I build pdf reference manual:

![Screenshot from 2021-12-23 15-57-30](https://user-images.githubusercontent.com/20852068/147210576-27b951e3-d7ad-4b78-909d-475de2030d4d.png)
![Screenshot from 2021-12-23 16-02-54](https://user-images.githubusercontent.com/20852068/147210583-4e99c157-532f-428c-b6c4-312d94f92a71.png)


My system:

Ubuntu 18.04
Doxygen: 1.8.13
pdfTeX 3.14159265-2.6-1.40.18 (TeX Live 2017/Debian)
So I change the Doxyfile and bib file to fix these errors:

add EXTRA_PACKAGES in Doxyfile
escape '%' in bib file