### PR TITLE
Cmake file rework

### DIFF
--- a/docs/gs-installing.dox
+++ b/docs/gs-installing.dox
@@ -95,20 +95,6 @@ source ~/.bashrc
 @endcode
 
 
-@section gs-install-cmake Upgrading CMake to Version 3.12
-
-We use a newer version of [cmake](https://cmake.org/download/) so you will probably need to upgrade your system if you are on an old ubuntu version.
-You can run the following which downloads a script and will install it for you.
-
-@code{.shell-session}
-wget https://cmake.org/files/v3.13/cmake-3.13.5-Linux-x86_64.sh
-sudo mkdir /opt/cmake
-sudo sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
-sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
-cmake --version
-@endcode
-
-
 @section gs-install-openvins Cloning the OpenVINS Project
 
 Now that we have ROS installed we can setup a catkin workspace and build the project!
@@ -131,9 +117,21 @@ git clone https://github.com/rpng/open_vins/
 cd ..
 catkin build # ROS1
 colcon build # ROS2
-colcon build --event-handlers console_cohesion+ # ROS2 with verbose output
+colcon build --event-handlers console_cohesion+ --packages-select ov_core ov_init ov_msckf ov_eval # ROS2 with verbose output
 @endcode
 
+If you do not have ROS installed, then you can do the following:
+
+
+@code{.shell-session}
+cd ~/github/
+git clone https://github.com/rpng/open_vins/
+cd open_vins/ov_msckf/
+mkdir build
+cd build
+cmake ..
+make -j4
+@endcode
 
 
 @section gs-install-oveval Additional Evaluation Requirements

--- a/ov_core/CMakeLists.txt
+++ b/ov_core/CMakeLists.txt
@@ -23,7 +23,7 @@ endif ()
 # check if we have our python libs files (will search for python3 then python2 installs)
 # sudo apt-get install python-matplotlib python-numpy python-dev
 # https://cmake.org/cmake/help/v3.10/module/FindPythonLibs.html
-find_package(PythonLibs)
+find_package(PythonLibs QUIET)
 option(DISABLE_MATPLOTLIB "Disable or enable matplotlib plot scripts in ov_eval" OFF)
 if (PYTHONLIBS_FOUND AND NOT DISABLE_MATPLOTLIB)
     add_definitions(-DHAVE_PYTHONLIBS=1)

--- a/ov_core/CMakeLists.txt
+++ b/ov_core/CMakeLists.txt
@@ -1,10 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
-
-# Define our install directories based on GNU conventions
-# https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
-include(GNUInstallDirs)
-
-# Project name
+cmake_minimum_required(VERSION 3.3)
 project(ov_core)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
@@ -28,17 +22,16 @@ endif ()
 
 # check if we have our python libs files (will search for python3 then python2 installs)
 # sudo apt-get install python-matplotlib python-numpy python-dev
-# https://cmake.org/cmake/help/latest/module/FindPython.html
-# https://stackoverflow.com/a/34580995/7718197
-find_package(Python COMPONENTS Interpreter Development)
+# https://cmake.org/cmake/help/v3.10/module/FindPythonLibs.html
+find_package(PythonLibs)
 option(DISABLE_MATPLOTLIB "Disable or enable matplotlib plot scripts in ov_eval" OFF)
-if (Python_FOUND AND NOT DISABLE_MATPLOTLIB)
+if (PYTHONLIBS_FOUND AND NOT DISABLE_MATPLOTLIB)
     add_definitions(-DHAVE_PYTHONLIBS=1)
-    message(STATUS "PYTHON VERSION: " ${Python_VERSION})
-    message(STATUS "PYTHON INCLUDE: " ${Python_INCLUDE_DIRS})
-    message(STATUS "PYTHON LIBRARIES: " ${Python_LIBRARIES})
-    include_directories(${Python_INCLUDE_DIRS})
-    list(APPEND thirdparty_libraries ${Python_LIBRARIES})
+    message(STATUS "PYTHON VERSION: " ${PYTHONLIBS_VERSION_STRING})
+    message(STATUS "PYTHON INCLUDE: " ${PYTHON_INCLUDE_DIRS})
+    message(STATUS "PYTHON LIBRARIES: " ${PYTHON_LIBRARIES})
+    include_directories(${PYTHON_INCLUDE_DIRS})
+    list(APPEND thirdparty_libraries ${PYTHON_LIBRARIES})
 endif ()
 
 # We need c++14 for ROS2, thus just require it for everybody
@@ -58,16 +51,16 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninit
 # NOTE: https://github.com/romainreignier/share_ros1_ros2_lib_demo
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)
-if(catkin_FOUND)
+if (catkin_FOUND)
     message(STATUS "ROS *1* version found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-elseif(ament_cmake_FOUND)
+elseif (ament_cmake_FOUND)
     message(STATUS "ROS *2* version found, building ROS2.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS2.cmake)
-else()
+else ()
     message(STATUS "No ROS versions found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-endif()
+endif ()
 
 
 

--- a/ov_core/cmake/ROS1.cmake
+++ b/ov_core/cmake/ROS1.cmake
@@ -9,21 +9,19 @@ if (catkin_FOUND AND ENABLE_ROS)
     add_definitions(-DROS_AVAILABLE=1)
     catkin_package(
             CATKIN_DEPENDS roscpp rosbag sensor_msgs cv_bridge
-            INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src/
+            INCLUDE_DIRS src/
             LIBRARIES ov_core_lib
     )
 else ()
     add_definitions(-DROS_AVAILABLE=0)
     message(WARNING "BUILDING WITHOUT ROS!")
+    include(GNUInstallDirs)
+    set(CATKIN_PACKAGE_LIB_DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    set(CATKIN_PACKAGE_BIN_DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    set(CATKIN_GLOBAL_INCLUDE_DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 endif ()
 
 # Include our header files
-message(WARNING "EIGEN3_INCLUDE_DIR ${EIGEN3_INCLUDE_DIR}")
-message(WARNING "Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS}")
-message(WARNING "catkin_INCLUDE_DIRS ${catkin_INCLUDE_DIRS}")
-message(WARNING "Boost_LIBRARIES ${Boost_LIBRARIES}")
-message(WARNING "OpenCV_LIBRARIES ${OpenCV_LIBRARIES}")
-message(WARNING "catkin_LIBRARIES ${catkin_LIBRARIES}")
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIR}
@@ -42,7 +40,7 @@ list(APPEND thirdparty_libraries
 # Make the core library
 ##################################################
 
-add_library(ov_core_lib SHARED
+list(APPEND LIBRARY_SOURCES
         src/dummy.cpp
         src/sim/BsplineSE3.cpp
         src/track/TrackBase.cpp
@@ -55,12 +53,18 @@ add_library(ov_core_lib SHARED
         src/feat/FeatureInitializer.cpp
         src/utils/print.cpp
 )
+file(GLOB_RECURSE LIBRARY_HEADERS "src/*.h")
+add_library(ov_core_lib SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 target_link_libraries(ov_core_lib ${thirdparty_libraries})
-target_include_directories(ov_core_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/)
+target_include_directories(ov_core_lib PUBLIC src/)
 install(TARGETS ov_core_lib
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(DIRECTORY src/
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
 
 ##################################################
@@ -71,15 +75,21 @@ if (catkin_FOUND AND ENABLE_ROS)
 
     add_executable(test_tracking src/test_tracking.cpp)
     target_link_libraries(test_tracking ov_core_lib ${thirdparty_libraries})
+    install(TARGETS test_tracking
+            ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
 
 endif ()
 
 add_executable(test_webcam src/test_webcam.cpp)
 target_link_libraries(test_webcam ov_core_lib ${thirdparty_libraries})
 install(TARGETS test_webcam
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
 
 

--- a/ov_core/cmake/ROS2.cmake
+++ b/ov_core/cmake/ROS2.cmake
@@ -29,7 +29,7 @@ list(APPEND thirdparty_libraries
 # Make the core library
 ##################################################
 
-add_library(ov_core_lib SHARED
+list(APPEND LIBRARY_SOURCES
         src/dummy.cpp
         src/sim/BsplineSE3.cpp
         src/track/TrackBase.cpp
@@ -42,15 +42,21 @@ add_library(ov_core_lib SHARED
         src/feat/FeatureInitializer.cpp
         src/utils/print.cpp
 )
+file(GLOB_RECURSE LIBRARY_HEADERS "src/*.h")
+add_library(ov_core_lib SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 ament_target_dependencies(ov_core_lib rclcpp cv_bridge)
 target_link_libraries(ov_core_lib ${thirdparty_libraries})
-target_include_directories(ov_core_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/)
+target_include_directories(ov_core_lib PUBLIC src/)
 install(TARGETS ov_core_lib
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        PUBLIC_HEADER DESTINATION include
 )
-ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/)
+install(DIRECTORY src/
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
+ament_export_include_directories(include)
 ament_export_libraries(ov_core_lib)
 
 ##################################################

--- a/ov_core/package.xml
+++ b/ov_core/package.xml
@@ -31,7 +31,6 @@
     <depend condition="$ROS_VERSION == 2">cv_bridge</depend>
 
     <!-- System dependencies for both versions -->
-    <depend version_gte="3.12">cmake</depend>
     <depend>eigen</depend>
     <depend>libopencv-dev</depend>
     <depend>libopencv-contrib-dev</depend>

--- a/ov_data/CMakeLists.txt
+++ b/ov_data/CMakeLists.txt
@@ -1,6 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
-
-# Project name
+cmake_minimum_required(VERSION 3.3)
 project(ov_data)
 
 # Find our ROS version!
@@ -8,12 +6,12 @@ project(ov_data)
 # NOTE: https://github.com/romainreignier/share_ros1_ros2_lib_demo
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)
-if(catkin_FOUND)
+if (catkin_FOUND)
     message(STATUS "ROS *1* version found")
     catkin_package()
-elseif(ament_cmake_FOUND)
+elseif (ament_cmake_FOUND)
     message(STATUS "ROS *2* version found")
     ament_package()
-else()
+else ()
     message(STATUS "No ROS versions found, doing nothing...")
-endif()
+endif ()

--- a/ov_data/package.xml
+++ b/ov_data/package.xml
@@ -22,9 +22,6 @@
     <!-- ROS2: Dependencies needed to compile this package. -->
     <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-    <!-- System dependencies for both versions -->
-    <depend version_gte="3.12">cmake</depend>
-
     <!-- Note the export is required to expose the executables -->
     <export>
         <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/ov_eval/CMakeLists.txt
+++ b/ov_eval/CMakeLists.txt
@@ -1,10 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
-
-# Define our install directories based on GNU conventions
-# https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
-include(GNUInstallDirs)
-
-# Project name
+cmake_minimum_required(VERSION 3.3)
 project(ov_eval)
 
 # Include libraries
@@ -13,17 +7,16 @@ find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 
 # check if we have our python libs files (will search for python3 then python2 installs)
 # sudo apt-get install python-matplotlib python-numpy python-dev
-# https://cmake.org/cmake/help/latest/module/FindPython.html
-# https://stackoverflow.com/a/34580995/7718197
-find_package(Python COMPONENTS Interpreter Development)
+# https://cmake.org/cmake/help/v3.10/module/FindPythonLibs.html
+find_package(PythonLibs)
 option(DISABLE_MATPLOTLIB "Disable or enable matplotlib plot scripts in ov_eval" OFF)
-if (Python_FOUND AND NOT DISABLE_MATPLOTLIB)
+if (PYTHONLIBS_FOUND AND NOT DISABLE_MATPLOTLIB)
     add_definitions(-DHAVE_PYTHONLIBS=1)
-    message(STATUS "PYTHON VERSION: " ${Python_VERSION})
-    message(STATUS "PYTHON INCLUDE: " ${Python_INCLUDE_DIRS})
-    message(STATUS "PYTHON LIBRARIES: " ${Python_LIBRARIES})
-    include_directories(${Python_INCLUDE_DIRS})
-    list(APPEND thirdparty_libraries ${Python_LIBRARIES})
+    message(STATUS "PYTHON VERSION: " ${PYTHONLIBS_VERSION_STRING})
+    message(STATUS "PYTHON INCLUDE: " ${PYTHON_INCLUDE_DIRS})
+    message(STATUS "PYTHON LIBRARIES: " ${PYTHON_LIBRARIES})
+    include_directories(${PYTHON_INCLUDE_DIRS})
+    list(APPEND thirdparty_libraries ${PYTHON_LIBRARIES})
 endif ()
 
 # We need c++14 for ROS2, thus just require it for everybody
@@ -43,14 +36,14 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninit
 # NOTE: https://github.com/romainreignier/share_ros1_ros2_lib_demo
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)
-if(catkin_FOUND)
+if (catkin_FOUND)
     message(STATUS "ROS *1* version found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-elseif(ament_cmake_FOUND)
+elseif (ament_cmake_FOUND)
     message(STATUS "ROS *2* version found, building ROS2.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS2.cmake)
-else()
+else ()
     message(STATUS "No ROS versions found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-endif()
+endif ()
 

--- a/ov_eval/CMakeLists.txt
+++ b/ov_eval/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 # check if we have our python libs files (will search for python3 then python2 installs)
 # sudo apt-get install python-matplotlib python-numpy python-dev
 # https://cmake.org/cmake/help/v3.10/module/FindPythonLibs.html
-find_package(PythonLibs)
+find_package(PythonLibs QUIET)
 option(DISABLE_MATPLOTLIB "Disable or enable matplotlib plot scripts in ov_eval" OFF)
 if (PYTHONLIBS_FOUND AND NOT DISABLE_MATPLOTLIB)
     add_definitions(-DHAVE_PYTHONLIBS=1)

--- a/ov_eval/cmake/ROS1.cmake
+++ b/ov_eval/cmake/ROS1.cmake
@@ -9,12 +9,16 @@ if (catkin_FOUND AND ENABLE_ROS)
     add_definitions(-DROS_AVAILABLE=1)
     catkin_package(
             CATKIN_DEPENDS roscpp rospy geometry_msgs nav_msgs sensor_msgs ov_core
-            INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src/
+            INCLUDE_DIRS src/
             LIBRARIES ov_eval_lib
     )
 else ()
     add_definitions(-DROS_AVAILABLE=0)
     message(WARNING "BUILDING WITHOUT ROS!")
+    include(GNUInstallDirs)
+    set(CATKIN_PACKAGE_LIB_DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    set(CATKIN_PACKAGE_BIN_DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    set(CATKIN_GLOBAL_INCLUDE_DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 endif ()
 
 # Include our header files
@@ -36,16 +40,23 @@ list(APPEND thirdparty_libraries
 # This isn't that elegant of a way, but this at least allows for building without ROS
 # See this stackoverflow answer: https://stackoverflow.com/a/11217008/7718197
 if (NOT catkin_FOUND OR NOT ENABLE_ROS)
-    message(WARNING "MANUALLY LINKING TO OV_CORE LIBRARY....")
-    include_directories(${ov_core_SOURCE_DIR}/src/)
-    list(APPEND thirdparty_libraries ov_core_lib)
+
+    message(STATUS "MANUALLY LINKING TO OV_CORE LIBRARY....")
+    include_directories(${CMAKE_SOURCE_DIR}/../ov_core/src/)
+    file(GLOB_RECURSE OVCORE_LIBRARY_SOURCES "${CMAKE_SOURCE_DIR}/../ov_core/src/*.cpp")
+    list(FILTER OVCORE_LIBRARY_SOURCES EXCLUDE REGEX ".*test_webcam\\.cpp$")
+    list(FILTER OVCORE_LIBRARY_SOURCES EXCLUDE REGEX ".*test_tracking\\.cpp$")
+    list(APPEND LIBRARY_SOURCES ${OVCORE_LIBRARY_SOURCES})
+    file(GLOB_RECURSE OVCORE_LIBRARY_HEADERS "${CMAKE_SOURCE_DIR}/../ov_core/src/*.h")
+    list(APPEND LIBRARY_HEADERS ${OVCORE_LIBRARY_HEADERS})
+
 endif ()
 
 ##################################################
 # Make the shared library
 ##################################################
 
-add_library(ov_eval_lib SHARED
+list(APPEND LIBRARY_SOURCES
         src/dummy.cpp
         src/alignment/AlignTrajectory.cpp
         src/alignment/AlignUtils.cpp
@@ -53,12 +64,18 @@ add_library(ov_eval_lib SHARED
         src/calc/ResultSimulation.cpp
         src/utils/Loader.cpp
 )
+file(GLOB_RECURSE LIBRARY_HEADERS "src/*.h")
+add_library(ov_eval_lib SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 target_link_libraries(ov_eval_lib ${thirdparty_libraries})
-target_include_directories(ov_eval_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/)
+target_include_directories(ov_eval_lib PUBLIC src/)
 install(TARGETS ov_eval_lib
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(DIRECTORY src/
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
 
 ##################################################
@@ -69,82 +86,93 @@ if (catkin_FOUND AND ENABLE_ROS)
 
     add_executable(pose_to_file src/pose_to_file.cpp)
     target_link_libraries(pose_to_file ov_eval_lib ${thirdparty_libraries})
+    install(TARGETS pose_to_file
+            ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
+    message(WARNING "${CATKIN_PACKAGE_LIB_DESTINATION}")
 
     add_executable(live_align_trajectory src/live_align_trajectory.cpp)
     target_link_libraries(live_align_trajectory ov_eval_lib ${thirdparty_libraries})
+    install(TARGETS live_align_trajectory
+            ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
 
 endif ()
 
 add_executable(format_converter src/format_converter.cpp)
 target_link_libraries(format_converter ov_eval_lib ${thirdparty_libraries})
 install(TARGETS format_converter
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 add_executable(error_comparison src/error_comparison.cpp)
 target_link_libraries(error_comparison ov_eval_lib ${thirdparty_libraries})
 install(TARGETS error_comparison
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 add_executable(error_dataset src/error_dataset.cpp)
 target_link_libraries(error_dataset ov_eval_lib ${thirdparty_libraries})
 install(TARGETS error_dataset
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 add_executable(error_singlerun src/error_singlerun.cpp)
 target_link_libraries(error_singlerun ov_eval_lib ${thirdparty_libraries})
 install(TARGETS error_singlerun
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 add_executable(error_simulation src/error_simulation.cpp)
 target_link_libraries(error_simulation ov_eval_lib ${thirdparty_libraries})
 install(TARGETS error_simulation
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 add_executable(timing_flamegraph src/timing_flamegraph.cpp)
 target_link_libraries(timing_flamegraph ov_eval_lib ${thirdparty_libraries})
 install(TARGETS timing_flamegraph
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 add_executable(timing_comparison src/timing_comparison.cpp)
 target_link_libraries(timing_comparison ov_eval_lib ${thirdparty_libraries})
 install(TARGETS timing_comparison
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 add_executable(timing_percentages src/timing_percentages.cpp)
 target_link_libraries(timing_percentages ov_eval_lib ${thirdparty_libraries})
 install(TARGETS timing_percentages
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        )
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 add_executable(plot_trajectories src/plot_trajectories.cpp)
 target_link_libraries(plot_trajectories ov_eval_lib ${thirdparty_libraries})
 install(TARGETS plot_trajectories
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 
@@ -158,3 +186,13 @@ if (catkin_FOUND AND ENABLE_ROS)
     catkin_install_python(PROGRAMS python/pid_sys.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 endif ()
+
+
+##################################################
+# Launch files!
+##################################################
+
+install(DIRECTORY launch/
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)
+

--- a/ov_eval/cmake/ROS2.cmake
+++ b/ov_eval/cmake/ROS2.cmake
@@ -29,7 +29,7 @@ list(APPEND thirdparty_libraries
 # Make the shared library
 ##################################################
 
-add_library(ov_eval_lib SHARED
+list(APPEND LIBRARY_SOURCES
         src/dummy.cpp
         src/alignment/AlignTrajectory.cpp
         src/alignment/AlignUtils.cpp
@@ -37,15 +37,21 @@ add_library(ov_eval_lib SHARED
         src/calc/ResultSimulation.cpp
         src/utils/Loader.cpp
 )
+file(GLOB_RECURSE LIBRARY_HEADERS "src/*.h")
+add_library(ov_eval_lib SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 ament_target_dependencies(ov_eval_lib rclcpp ov_core)
 target_link_libraries(ov_eval_lib ${thirdparty_libraries})
-target_include_directories(ov_eval_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/)
+target_include_directories(ov_eval_lib PUBLIC src/)
 install(TARGETS ov_eval_lib
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        PUBLIC_HEADER DESTINATION include
 )
-ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/)
+install(DIRECTORY src/
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
+ament_export_include_directories(include)
 ament_export_libraries(ov_eval_lib)
 
 ##################################################

--- a/ov_eval/package.xml
+++ b/ov_eval/package.xml
@@ -33,7 +33,6 @@
     <depend condition="$ROS_VERSION == 2">ov_core</depend>
 
     <!-- System dependencies for both versions -->
-    <depend version_gte="3.12">cmake</depend>
     <depend>eigen</depend>
     <depend>boost</depend>
 

--- a/ov_init/CMakeLists.txt
+++ b/ov_init/CMakeLists.txt
@@ -1,10 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
-
-# Define our install directories based on GNU conventions
-# https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
-include(GNUInstallDirs)
-
-# Project name
+cmake_minimum_required(VERSION 3.3)
 project(ov_init)
 
 # Include libraries
@@ -13,17 +7,16 @@ find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 
 # check if we have our python libs files (will search for python3 then python2 installs)
 # sudo apt-get install python-matplotlib python-numpy python-dev
-# https://cmake.org/cmake/help/latest/module/FindPython.html
-# https://stackoverflow.com/a/34580995/7718197
-find_package(Python COMPONENTS Interpreter Development)
+# https://cmake.org/cmake/help/v3.10/module/FindPythonLibs.html
+find_package(PythonLibs)
 option(DISABLE_MATPLOTLIB "Disable or enable matplotlib plot scripts in ov_eval" OFF)
-if (Python_FOUND AND NOT DISABLE_MATPLOTLIB)
+if (PYTHONLIBS_FOUND AND NOT DISABLE_MATPLOTLIB)
     add_definitions(-DHAVE_PYTHONLIBS=1)
-    message(STATUS "PYTHON VERSION: " ${Python_VERSION})
-    message(STATUS "PYTHON INCLUDE: " ${Python_INCLUDE_DIRS})
-    message(STATUS "PYTHON LIBRARIES: " ${Python_LIBRARIES})
-    include_directories(${Python_INCLUDE_DIRS})
-    list(APPEND thirdparty_libraries ${Python_LIBRARIES})
+    message(STATUS "PYTHON VERSION: " ${PYTHONLIBS_VERSION_STRING})
+    message(STATUS "PYTHON INCLUDE: " ${PYTHON_INCLUDE_DIRS})
+    message(STATUS "PYTHON LIBRARIES: " ${PYTHON_LIBRARIES})
+    include_directories(${PYTHON_INCLUDE_DIRS})
+    list(APPEND thirdparty_libraries ${PYTHON_LIBRARIES})
 endif ()
 
 # We need c++14 for ROS2, thus just require it for everybody
@@ -43,14 +36,14 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninit
 # NOTE: https://github.com/romainreignier/share_ros1_ros2_lib_demo
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)
-if(catkin_FOUND)
+if (catkin_FOUND)
     message(STATUS "ROS *1* version found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-elseif(ament_cmake_FOUND)
+elseif (ament_cmake_FOUND)
     message(STATUS "ROS *2* version found, building ROS2.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS2.cmake)
-else()
+else ()
     message(STATUS "No ROS versions found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-endif()
+endif ()
 

--- a/ov_init/CMakeLists.txt
+++ b/ov_init/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 # check if we have our python libs files (will search for python3 then python2 installs)
 # sudo apt-get install python-matplotlib python-numpy python-dev
 # https://cmake.org/cmake/help/v3.10/module/FindPythonLibs.html
-find_package(PythonLibs)
+find_package(PythonLibs QUIET)
 option(DISABLE_MATPLOTLIB "Disable or enable matplotlib plot scripts in ov_eval" OFF)
 if (PYTHONLIBS_FOUND AND NOT DISABLE_MATPLOTLIB)
     add_definitions(-DHAVE_PYTHONLIBS=1)

--- a/ov_init/cmake/ROS1.cmake
+++ b/ov_init/cmake/ROS1.cmake
@@ -9,12 +9,16 @@ if (catkin_FOUND AND ENABLE_ROS)
     add_definitions(-DROS_AVAILABLE=1)
     catkin_package(
             CATKIN_DEPENDS roscpp ov_core
-            INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src/
+            INCLUDE_DIRS src/
             LIBRARIES ov_init_lib
     )
 else ()
     add_definitions(-DROS_AVAILABLE=0)
     message(WARNING "BUILDING WITHOUT ROS!")
+    include(GNUInstallDirs)
+    set(CATKIN_PACKAGE_LIB_DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    set(CATKIN_PACKAGE_BIN_DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    set(CATKIN_GLOBAL_INCLUDE_DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 endif ()
 
 # Include our header files
@@ -35,26 +39,39 @@ list(APPEND thirdparty_libraries
 # This isn't that elegant of a way, but this at least allows for building without ROS
 # See this stackoverflow answer: https://stackoverflow.com/a/11217008/7718197
 if (NOT catkin_FOUND OR NOT ENABLE_ROS)
-    message(WARNING "MANUALLY LINKING TO OV_CORE LIBRARY....")
-    include_directories(${ov_core_SOURCE_DIR}/src/)
-    list(APPEND thirdparty_libraries ov_core_lib)
+
+    message(STATUS "MANUALLY LINKING TO OV_CORE LIBRARY....")
+    include_directories(${CMAKE_SOURCE_DIR}/../ov_core/src/)
+    file(GLOB_RECURSE OVCORE_LIBRARY_SOURCES "${CMAKE_SOURCE_DIR}/../ov_core/src/*.cpp")
+    list(FILTER OVCORE_LIBRARY_SOURCES EXCLUDE REGEX ".*test_webcam\\.cpp$")
+    list(FILTER OVCORE_LIBRARY_SOURCES EXCLUDE REGEX ".*test_tracking\\.cpp$")
+    list(APPEND LIBRARY_SOURCES ${OVCORE_LIBRARY_SOURCES})
+    file(GLOB_RECURSE OVCORE_LIBRARY_HEADERS "${CMAKE_SOURCE_DIR}/../ov_core/src/*.h")
+    list(APPEND LIBRARY_HEADERS ${OVCORE_LIBRARY_HEADERS})
+
 endif ()
 
 ##################################################
 # Make the shared library
 ##################################################
 
-add_library(ov_init_lib SHARED
+list(APPEND LIBRARY_SOURCES
         src/dummy.cpp
         src/init/InertialInitializer.cpp
         src/static/StaticInitializer.cpp
 )
+file(GLOB_RECURSE LIBRARY_HEADERS "src/*.h")
+add_library(ov_init_lib SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 target_link_libraries(ov_init_lib ${thirdparty_libraries})
-target_include_directories(ov_init_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/)
+target_include_directories(ov_init_lib PUBLIC src/)
 install(TARGETS ov_init_lib
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(DIRECTORY src/
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
 
 

--- a/ov_init/cmake/ROS2.cmake
+++ b/ov_init/cmake/ROS2.cmake
@@ -29,20 +29,26 @@ list(APPEND thirdparty_libraries
 # Make the shared library
 ##################################################
 
-add_library(ov_init_lib SHARED
+list(APPEND LIBRARY_SOURCES
         src/dummy.cpp
         src/init/InertialInitializer.cpp
         src/static/StaticInitializer.cpp
 )
+file(GLOB_RECURSE LIBRARY_HEADERS "src/*.h")
+add_library(ov_init_lib SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 ament_target_dependencies(ov_init_lib rclcpp ov_core cv_bridge)
 target_link_libraries(ov_init_lib ${thirdparty_libraries})
-target_include_directories(ov_init_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/)
+target_include_directories(ov_init_lib PUBLIC src/)
 install(TARGETS ov_init_lib
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        PUBLIC_HEADER DESTINATION include
 )
-ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/)
+install(DIRECTORY src/
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
+ament_export_include_directories(include)
 ament_export_libraries(ov_init_lib)
 
 

--- a/ov_init/src/static/StaticInitializer.h
+++ b/ov_init/src/static/StaticInitializer.h
@@ -22,9 +22,9 @@
 #ifndef OV_INIT_STATICINITIALIZER_H
 #define OV_INIT_STATICINITIALIZER_H
 
-#include "feat/FeatureHelper.h"
 #include "init/InertialInitializerOptions.h"
 
+#include "feat/FeatureHelper.h"
 #include "types/IMU.h"
 #include "utils/colors.h"
 #include "utils/print.h"

--- a/ov_msckf/CMakeLists.txt
+++ b/ov_msckf/CMakeLists.txt
@@ -1,10 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
-
-# Define our install directories based on GNU conventions
-# https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
-include(GNUInstallDirs)
-
-# Project name
+cmake_minimum_required(VERSION 3.3)
 project(ov_msckf)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
@@ -43,16 +37,16 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninit
 # NOTE: https://github.com/romainreignier/share_ros1_ros2_lib_demo
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)
-if(catkin_FOUND)
+if (catkin_FOUND)
     message(STATUS "ROS *1* version found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-elseif(ament_cmake_FOUND)
+elseif (ament_cmake_FOUND)
     message(STATUS "ROS *2* version found, building ROS2.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS2.cmake)
-else()
+else ()
     message(STATUS "No ROS versions found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-endif()
+endif ()
 
 
 

--- a/ov_msckf/cmake/ROS1.cmake
+++ b/ov_msckf/cmake/ROS1.cmake
@@ -9,12 +9,16 @@ if (catkin_FOUND AND ENABLE_ROS)
     add_definitions(-DROS_AVAILABLE=1)
     catkin_package(
             CATKIN_DEPENDS roscpp rosbag tf std_msgs geometry_msgs sensor_msgs nav_msgs visualization_msgs image_transport cv_bridge ov_core ov_init
-            INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src/
+            INCLUDE_DIRS src/
             LIBRARIES ov_msckf_lib
     )
 else ()
     add_definitions(-DROS_AVAILABLE=0)
     message(WARNING "BUILDING WITHOUT ROS!")
+    include(GNUInstallDirs)
+    set(CATKIN_PACKAGE_LIB_DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    set(CATKIN_PACKAGE_BIN_DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    set(CATKIN_GLOBAL_INCLUDE_DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 endif ()
 
 
@@ -39,29 +43,21 @@ list(APPEND thirdparty_libraries
 # But since we don't we need to basically build all the cpp / h files explicitly :(
 if (NOT catkin_FOUND OR NOT ENABLE_ROS)
 
-    message(WARNING "MANUALLY LINKING TO OV_CORE LIBRARY....")
+    message(STATUS "MANUALLY LINKING TO OV_CORE LIBRARY....")
     include_directories(${CMAKE_SOURCE_DIR}/../ov_core/src/)
-    file(GLOB_RECURSE ov_core_files "${CMAKE_SOURCE_DIR}/../ov_core/src/cam/*.cpp")
-    list(APPEND library_source_files ${ov_core_files})
-    file(GLOB_RECURSE ov_core_files "${CMAKE_SOURCE_DIR}/../ov_core/src/cpi/*.cpp")
-    list(APPEND library_source_files ${ov_core_files})
-    file(GLOB_RECURSE ov_core_files "${CMAKE_SOURCE_DIR}/../ov_core/src/feat/*.cpp")
-    list(APPEND library_source_files ${ov_core_files})
-    file(GLOB_RECURSE ov_core_files "${CMAKE_SOURCE_DIR}/../ov_core/src/plot/*.cpp")
-    list(APPEND library_source_files ${ov_core_files})
-    file(GLOB_RECURSE ov_core_files "${CMAKE_SOURCE_DIR}/../ov_core/src/sim/*.cpp")
-    list(APPEND library_source_files ${ov_core_files})
-    file(GLOB_RECURSE ov_core_files "${CMAKE_SOURCE_DIR}/../ov_core/src/track/*.cpp")
-    list(APPEND library_source_files ${ov_core_files})
-    file(GLOB_RECURSE ov_core_files "${CMAKE_SOURCE_DIR}/../ov_core/src/types/*.cpp")
-    list(APPEND library_source_files ${ov_core_files})
-    file(GLOB_RECURSE ov_core_files "${CMAKE_SOURCE_DIR}/../ov_core/src/utils/*.cpp")
-    list(APPEND library_source_files ${ov_core_files})
+    file(GLOB_RECURSE OVCORE_LIBRARY_SOURCES "${CMAKE_SOURCE_DIR}/../ov_core/src/*.cpp")
+    list(FILTER OVCORE_LIBRARY_SOURCES EXCLUDE REGEX ".*test_webcam\\.cpp$")
+    list(FILTER OVCORE_LIBRARY_SOURCES EXCLUDE REGEX ".*test_tracking\\.cpp$")
+    list(APPEND LIBRARY_SOURCES ${OVCORE_LIBRARY_SOURCES})
+    file(GLOB_RECURSE OVCORE_LIBRARY_HEADERS "${CMAKE_SOURCE_DIR}/../ov_core/src/*.h")
+    list(APPEND LIBRARY_HEADERS ${OVCORE_LIBRARY_HEADERS})
 
-    message(WARNING "MANUALLY LINKING TO OV_INIT LIBRARY....")
+    message(STATUS "MANUALLY LINKING TO OV_INIT LIBRARY....")
     include_directories(${CMAKE_SOURCE_DIR}/../ov_init/src/)
-    file(GLOB_RECURSE ov_init_files "${CMAKE_SOURCE_DIR}/../ov_init/src/*.[hc]pp")
-    list(APPEND library_source_files ${ov_init_files})
+    file(GLOB_RECURSE OVINIT_LIBRARY_SOURCES "${CMAKE_SOURCE_DIR}/../ov_init/src/*.cpp")
+    list(APPEND LIBRARY_SOURCES ${OVINIT_LIBRARY_SOURCES})
+    file(GLOB_RECURSE OVINIT_LIBRARY_HEADERS "${CMAKE_SOURCE_DIR}/../ov_init/src/*.h")
+    list(APPEND LIBRARY_HEADERS ${OVINIT_LIBRARY_HEADERS})
 
 endif ()
 
@@ -69,7 +65,8 @@ endif ()
 # Make the shared library
 ##################################################
 
-list(APPEND library_source_files
+list(APPEND LIBRARY_SOURCES
+        src/dummy.cpp
         src/sim/Simulator.cpp
         src/state/State.cpp
         src/state/StateHelper.cpp
@@ -81,17 +78,20 @@ list(APPEND library_source_files
         src/update/UpdaterZeroVelocity.cpp
 )
 if (catkin_FOUND AND ENABLE_ROS)
-    list(APPEND library_source_files
-            src/ros/ROS1Visualizer.cpp
-    )
+    list(APPEND LIBRARY_SOURCES src/ros/ROS1Visualizer.cpp)
 endif ()
-add_library(ov_msckf_lib SHARED ${library_source_files})
+file(GLOB_RECURSE LIBRARY_HEADERS "src/*.h")
+add_library(ov_msckf_lib SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 target_link_libraries(ov_msckf_lib ${thirdparty_libraries})
-target_include_directories(ov_msckf_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/)
+target_include_directories(ov_msckf_lib PUBLIC src/)
 install(TARGETS ov_msckf_lib
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(DIRECTORY src/
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
 
 ##################################################
@@ -102,34 +102,53 @@ if (catkin_FOUND AND ENABLE_ROS)
 
     add_executable(ros1_serial_msckf src/ros1_serial_msckf.cpp)
     target_link_libraries(ros1_serial_msckf ov_msckf_lib ${thirdparty_libraries})
+    install(TARGETS ros1_serial_msckf
+            ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
 
     add_executable(run_subscribe_msckf src/run_subscribe_msckf.cpp)
     target_link_libraries(run_subscribe_msckf ov_msckf_lib ${thirdparty_libraries})
+    install(TARGETS run_subscribe_msckf
+            ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
 
 endif ()
 
 add_executable(run_simulation src/run_simulation.cpp)
 target_link_libraries(run_simulation ov_msckf_lib ${thirdparty_libraries})
 install(TARGETS run_simulation
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 add_executable(test_sim_meas src/test_sim_meas.cpp)
 target_link_libraries(test_sim_meas ov_msckf_lib ${thirdparty_libraries})
 install(TARGETS test_sim_meas
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 add_executable(test_sim_repeat src/test_sim_repeat.cpp)
 target_link_libraries(test_sim_repeat ov_msckf_lib ${thirdparty_libraries})
 install(TARGETS test_sim_repeat
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+
+##################################################
+# Launch files!
+##################################################
+
+install(DIRECTORY launch/
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )
 
 

--- a/ov_msckf/cmake/ROS2.cmake
+++ b/ov_msckf/cmake/ROS2.cmake
@@ -49,7 +49,8 @@ list(APPEND ament_libraries
 # Make the shared library
 ##################################################
 
-list(APPEND library_source_files
+list(APPEND LIBRARY_SOURCES
+        src/dummy.cpp
         src/sim/Simulator.cpp
         src/state/State.cpp
         src/state/StateHelper.cpp
@@ -60,19 +61,22 @@ list(APPEND library_source_files
         src/update/UpdaterSLAM.cpp
         src/update/UpdaterZeroVelocity.cpp
 )
-list(APPEND library_source_files
-        src/ros/ROS2Visualizer.cpp
-)
-add_library(ov_msckf_lib SHARED ${library_source_files})
+list(APPEND LIBRARY_SOURCES src/ros/ROS2Visualizer.cpp)
+file(GLOB_RECURSE LIBRARY_HEADERS "src/*.h")
+add_library(ov_msckf_lib SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 ament_target_dependencies(ov_msckf_lib ${ament_libraries})
 target_link_libraries(ov_msckf_lib ${thirdparty_libraries})
-target_include_directories(ov_msckf_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/)
+target_include_directories(ov_msckf_lib PUBLIC src/)
 install(TARGETS ov_msckf_lib
-        LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        PUBLIC_HEADER DESTINATION include
 )
-ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/)
+install(DIRECTORY src/
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
+ament_export_include_directories(include)
 ament_export_libraries(ov_msckf_lib)
 
 ##################################################
@@ -104,8 +108,8 @@ target_link_libraries(test_sim_repeat ov_msckf_lib ${thirdparty_libraries})
 install(TARGETS test_sim_repeat DESTINATION lib/${PROJECT_NAME})
 
 # Install launch and config directories
-install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
-install(DIRECTORY ../config/ DESTINATION share/${PROJECT_NAME}/)
+install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch/)
+install(DIRECTORY ../config/ DESTINATION share/${PROJECT_NAME}/config/)
 
 # finally define this as the package
 ament_package()

--- a/ov_msckf/package.xml
+++ b/ov_msckf/package.xml
@@ -47,7 +47,6 @@
     <depend condition="$ROS_VERSION == 2">ov_init</depend>
 
     <!-- System dependencies for both versions -->
-    <depend version_gte="3.12">cmake</depend>
     <depend>eigen</depend>
     <depend>libopencv-dev</depend>
     <depend>libopencv-contrib-dev</depend>


### PR DESCRIPTION
This tries to rework the cmake system to better support ROS 1 and ROS 2 building and installing the package. Additionally, this reduces the cmake version requirement to 3.3 which should make it easier to install (original 3.12 was needed to find python, and this PR converts it to using the `PythonLibs` cmake config instead.
```
catkin config --install
catkin build
```
