### PR TITLE
Fix newer eigen asserts for ROS1 viz

### DIFF
--- a/ov_msckf/src/ros/ROS1Visualizer.cpp
+++ b/ov_msckf/src/ros/ROS1Visualizer.cpp
@@ -706,7 +706,13 @@ void ROS1Visualizer::publish_groundtruth() {
   Eigen::Matrix<double, 6, 6> covariance = StateHelper::get_marginal_covariance(_app->get_state(), statevars);
 
   // Calculate NEES values
-  double ori_nees = 2 * quat_diff.block(0, 0, 3, 1).dot(covariance.block(0, 0, 3, 3).inverse() * 2 * quat_diff.block(0, 0, 3, 1));
+  // NOTE: need to manually multiply things out to make static asserts work
+  // NOTE: https://github.com/rpng/open_vins/pull/226
+  // NOTE: https://github.com/rpng/open_vins/issues/236
+  // NOTE: https://gitlab.com/libeigen/eigen/-/issues/1664
+  Eigen::Vector3d quat_diff_vec = quat_diff.block(0, 0, 3, 1);
+  Eigen::Vector3d cov_vec = covariance.block(0, 0, 3, 3).inverse() * 2 * quat_diff.block(0, 0, 3, 1);
+  double ori_nees = 2 * quat_diff_vec.dot(cov_vec);
   Eigen::Vector3d errpos = state_ekf.block(4, 0, 3, 1) - state_gt.block(5, 0, 3, 1);
   double pos_nees = errpos.transpose() * covariance.block(3, 3, 3, 3).inverse() * errpos;
 

--- a/ov_msckf/src/ros/ROS2Visualizer.cpp
+++ b/ov_msckf/src/ros/ROS2Visualizer.cpp
@@ -713,6 +713,10 @@ void ROS2Visualizer::publish_groundtruth() {
   Eigen::Matrix<double, 6, 6> covariance = StateHelper::get_marginal_covariance(_app->get_state(), statevars);
 
   // Calculate NEES values
+  // NOTE: need to manually multiply things out to make static asserts work
+  // NOTE: https://github.com/rpng/open_vins/pull/226
+  // NOTE: https://github.com/rpng/open_vins/issues/236
+  // NOTE: https://gitlab.com/libeigen/eigen/-/issues/1664
   Eigen::Vector3d quat_diff_vec = quat_diff.block(0, 0, 3, 1);
   Eigen::Vector3d cov_vec = covariance.block(0, 0, 3, 3).inverse() * 2 * quat_diff.block(0, 0, 3, 1);
   double ori_nees = 2 * quat_diff_vec.dot(cov_vec);


### PR DESCRIPTION
```
/home/user/open_vins/catkin_ws/src/open_vins/ov_msckf/src/ros/ROS1Visualizer.cpp:709:129:   required from here
/usr/include/eigen3/Eigen/src/Core/Dot.h:74:3: error: static assertion failed: YOU_TRIED_CALLING_A_VECTOR_METHOD_ON_A_MATRIX
   74 |   EIGEN_STATIC_ASSERT_VECTOR_ONLY(Derived)
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/eigen3/Eigen/src/Core/Dot.h:75:3: error: static assertion failed: YOU_TRIED_CALLING_A_VECTOR_METHOD_ON_A_MATRIX
   75 |   EIGEN_STATIC_ASSERT_VECTOR_ONLY(OtherDerived)
```

See #236 and #226 and #121