### PR TITLE
fix display problem if the track length of feature is very long

### DIFF
--- a/ov_core/src/track/TrackBase.cpp
+++ b/ov_core/src/track/TrackBase.cpp
@@ -191,9 +191,9 @@ void TrackBase::display_history(cv::Mat &img_out, int r1, int g1, int b1, int r2
           break;
         // Calculate what color we are drawing in
         bool is_stereo = (feat.uvs.size() > 1);
-        int color_r = (is_stereo ? b2 : r2) - (int)((is_stereo ? b1 : r1) / feat.uvs[pair.first].size() * z);
-        int color_g = (is_stereo ? r2 : g2) - (int)((is_stereo ? r1 : g1) / feat.uvs[pair.first].size() * z);
-        int color_b = (is_stereo ? g2 : b2) - (int)((is_stereo ? g1 : b1) / feat.uvs[pair.first].size() * z);
+        int color_r = (is_stereo ? b2 : r2) - (int)(1.0 * (is_stereo ? b1 : r1) / feat.uvs[pair.first].size() * z);
+        int color_g = (is_stereo ? r2 : g2) - (int)(1.0 * (is_stereo ? r1 : g1) / feat.uvs[pair.first].size() * z);
+        int color_b = (is_stereo ? g2 : b2) - (int)(1.0 * (is_stereo ? g1 : b1) / feat.uvs[pair.first].size() * z);
         // Draw current point
         cv::Point2f pt_c(feat.uvs[pair.first].at(z)(0), feat.uvs[pair.first].at(z)(1));
         cv::circle(img_temp, pt_c, (is_small) ? 1 : 2, cv::Scalar(color_r, color_g, color_b), cv::FILLED);


### PR DESCRIPTION
This color of trajectory of a feature with too long track length on the display image will be white current now. This problem is caused by the property of integer division, so I multiplied the first by 1.0 to turn the result into a float number, avoiding this problem.