### PR TITLE
fix: link errors

### DIFF
--- a/ov_core/src/utils/print.h
+++ b/ov_core/src/utils/print.h
@@ -105,7 +105,7 @@ private:
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern void __assert(const char *msg, const char *file, int line);
+extern void __assert(const char *msg, const char *file, int line) throw ();
 #ifdef __cplusplus
 };
 #endif


### PR DESCRIPTION
link error arise from different declarations of function `__assert` in `print.h` from `/usr/include/assert.h`