### PR TITLE
Enable building without ROS even if you have ROS

### DIFF
--- a/ov_core/CMakeLists.txt
+++ b/ov_core/CMakeLists.txt
@@ -11,6 +11,9 @@ endif ()
 find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION})
 
+# By default we build with ROS, but you can disable this and just build as a library
+option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
+
 # If we will compile with aruco support
 option(ENABLE_ARUCO_TAGS "Enable or disable aruco tag (disable if no contrib modules)" ON)
 if (NOT ENABLE_ARUCO_TAGS)
@@ -51,14 +54,14 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninit
 # NOTE: https://github.com/romainreignier/share_ros1_ros2_lib_demo
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)
-if (catkin_FOUND)
+if (catkin_FOUND AND ENABLE_ROS)
     message(STATUS "ROS *1* version found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-elseif (ament_cmake_FOUND)
+elseif (ament_cmake_FOUND AND ENABLE_ROS)
     message(STATUS "ROS *2* version found, building ROS2.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS2.cmake)
 else ()
-    message(STATUS "No ROS versions found, building ROS1.cmake")
+    message(STATUS "No ROS versions found or building with ROS disabled, building ROS1.cmake without ROS")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
 endif ()
 

--- a/ov_core/cmake/ROS1.cmake
+++ b/ov_core/cmake/ROS1.cmake
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.3)
 find_package(catkin QUIET COMPONENTS roscpp rosbag sensor_msgs cv_bridge)
 
 # Describe ROS project
-option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
 if (catkin_FOUND AND ENABLE_ROS)
     add_definitions(-DROS_AVAILABLE=1)
     catkin_package(

--- a/ov_eval/CMakeLists.txt
+++ b/ov_eval/CMakeLists.txt
@@ -5,6 +5,9 @@ project(ov_eval)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 
+# By default we build with ROS, but you can disable this and just build as a library
+option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
+
 # check if we have our python libs files (will search for python3 then python2 installs)
 # sudo apt-get install python-matplotlib python-numpy python-dev
 # https://cmake.org/cmake/help/v3.10/module/FindPythonLibs.html
@@ -36,14 +39,14 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninit
 # NOTE: https://github.com/romainreignier/share_ros1_ros2_lib_demo
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)
-if (catkin_FOUND)
+if (catkin_FOUND AND ENABLE_ROS)
     message(STATUS "ROS *1* version found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-elseif (ament_cmake_FOUND)
+elseif (ament_cmake_FOUND AND ENABLE_ROS)
     message(STATUS "ROS *2* version found, building ROS2.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS2.cmake)
 else ()
-    message(STATUS "No ROS versions found, building ROS1.cmake")
+    message(STATUS "No ROS versions found or building with ROS disabled, building ROS1.cmake without ROS")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
 endif ()
 

--- a/ov_eval/cmake/ROS1.cmake
+++ b/ov_eval/cmake/ROS1.cmake
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.3)
 find_package(catkin QUIET COMPONENTS roscpp rospy geometry_msgs nav_msgs sensor_msgs ov_core)
 
 # Describe ROS project
-option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
 if (catkin_FOUND AND ENABLE_ROS)
     add_definitions(-DROS_AVAILABLE=1)
     catkin_package(

--- a/ov_init/CMakeLists.txt
+++ b/ov_init/CMakeLists.txt
@@ -13,6 +13,9 @@ find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 find_package(Ceres REQUIRED)
 message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION} " | CERES: " ${Ceres_VERSION})
 
+# By default we build with ROS, but you can disable this and just build as a library
+option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
+
 # check if we have our python libs files (will search for python3 then python2 installs)
 # sudo apt-get install python-matplotlib python-numpy python-dev
 # https://cmake.org/cmake/help/v3.10/module/FindPythonLibs.html
@@ -44,14 +47,14 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninit
 # NOTE: https://github.com/romainreignier/share_ros1_ros2_lib_demo
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)
-if (catkin_FOUND)
+if (catkin_FOUND AND ENABLE_ROS)
     message(STATUS "ROS *1* version found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-elseif (ament_cmake_FOUND)
+elseif (ament_cmake_FOUND AND ENABLE_ROS)
     message(STATUS "ROS *2* version found, building ROS2.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS2.cmake)
 else ()
-    message(STATUS "No ROS versions found, building ROS1.cmake")
+    message(STATUS "No ROS versions found or building with ROS disabled, building ROS1.cmake without ROS")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
 endif ()
 

--- a/ov_init/cmake/ROS1.cmake
+++ b/ov_init/cmake/ROS1.cmake
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.3)
 find_package(catkin QUIET COMPONENTS roscpp ov_core)
 
 # Describe ROS project
-option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
 if (catkin_FOUND AND ENABLE_ROS)
     add_definitions(-DROS_AVAILABLE=1)
     catkin_package(

--- a/ov_msckf/CMakeLists.txt
+++ b/ov_msckf/CMakeLists.txt
@@ -33,19 +33,22 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-sign
 # Enable debug flags (use if you want to debug in gdb)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -fno-omit-frame-pointer")
 
+
+option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
+
 # Find our ROS version!
 # NOTE: Default to using the ROS1 package if both are in our enviroment
 # NOTE: https://github.com/romainreignier/share_ros1_ros2_lib_demo
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)
-if (catkin_FOUND)
+if (catkin_FOUND AND ENABLE_ROS)
     message(STATUS "ROS *1* version found, building ROS1.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
-elseif (ament_cmake_FOUND)
+elseif (ament_cmake_FOUND AND ENABLE_ROS)
     message(STATUS "ROS *2* version found, building ROS2.cmake")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS2.cmake)
 else ()
-    message(STATUS "No ROS versions found, building ROS1.cmake")
+    message(STATUS "No ROS versions found or building with ROS disabled, building ROS1.cmake without ROS")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ROS1.cmake)
 endif ()
 

--- a/ov_msckf/CMakeLists.txt
+++ b/ov_msckf/CMakeLists.txt
@@ -12,6 +12,9 @@ find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 find_package(Ceres REQUIRED)
 message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION} " | CERES: " ${Ceres_VERSION})
 
+# By default we build with ROS, but you can disable this and just build as a library
+option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
+
 # If we will compile with aruco support
 option(ENABLE_ARUCO_TAGS "Enable or disable aruco tag (disable if no contrib modules)" ON)
 if (NOT ENABLE_ARUCO_TAGS)
@@ -32,9 +35,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-sign
 
 # Enable debug flags (use if you want to debug in gdb)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -fno-omit-frame-pointer")
-
-
-option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
 
 # Find our ROS version!
 # NOTE: Default to using the ROS1 package if both are in our enviroment

--- a/ov_msckf/cmake/ROS1.cmake
+++ b/ov_msckf/cmake/ROS1.cmake
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.3)
 find_package(catkin QUIET COMPONENTS roscpp rosbag tf std_msgs geometry_msgs sensor_msgs nav_msgs visualization_msgs image_transport cv_bridge ov_core ov_init)
 
 # Describe ROS project
-option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)
 if (catkin_FOUND AND ENABLE_ROS)
     add_definitions(-DROS_AVAILABLE=1)
     catkin_package(


### PR DESCRIPTION
I want to build without ROS enabled even though I have ROS2 installed. While following [this guide](https://docs.openvins.com/gs-installing-free.html), I found that in the current CMake, `-DENABLE_ROS=OFF` will be ignored if you have ROS2 installed (since it goes directly to ROS2.cmake instead of ROS1.cmake). This PR makes it so you can build without ROS if you so choose, even if you have it installed. 

Please let me know if you need any further information or require changes :smile: 