### PR TITLE
ROS2Visualizer: fixed build warnings

### DIFF
--- a/ov_msckf/src/ros/ROS2Visualizer.h
+++ b/ov_msckf/src/ros/ROS2Visualizer.h
@@ -25,7 +25,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/time_synchronizer.h>


### PR DESCRIPTION
Description: fixed deprecated headers

category: small fix

test status: tested on ros2 galactic and humble