### PR TITLE
Added support for ROS2 Jazzy and Ubuntu 24.04

### DIFF
--- a/.github/workflows/build_ros2.yml
+++ b/.github/workflows/build_ros2.yml
@@ -70,3 +70,24 @@ jobs:
 #      - name: Run OpenVINS Simulation!
 #        run: |
 #          docker run -t --mount type=bind,source=$GITHUB_WORKSPACE,target=/catkin_ws openvins /bin/bash -c "cd /catkin_ws && source install/setup.bash && ros2 run ov_msckf run_simulation src/open_vins/config/rpng_sim/estimator_config.yaml"
+  build_2404:
+    name: "ROS2 Ubuntu 24.04"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v2
+      - name: Create Workspace and Docker Image
+        run: |
+          export REPO=$(basename $GITHUB_REPOSITORY) &&
+          cd $GITHUB_WORKSPACE/.. && mkdir src/ &&
+          mv $REPO/ src/ && mkdir $REPO/ && mv src/ $REPO/ && cd $REPO/ &&
+          docker build -t openvins -f $GITHUB_WORKSPACE/src/$REPO/Dockerfile_ros2_24_04 .
+      - name: Echo Enviroment
+        run: |
+          docker run -t --mount type=bind,source=$GITHUB_WORKSPACE,target=/catkin_ws openvins /bin/bash -c "echo $ROS_DISTRO && echo $ROS_VERSION"
+      - name: Run Build in Docker
+        run: |
+          docker run -t --mount type=bind,source=$GITHUB_WORKSPACE,target=/catkin_ws openvins /bin/bash -c "cd /catkin_ws && colcon build"
+      - name: Run OpenVINS Simulation!
+        run: |
+          docker run -t --mount type=bind,source=$GITHUB_WORKSPACE,target=/catkin_ws openvins /bin/bash -c "cd /catkin_ws && source install/setup.bash && ros2 run ov_msckf run_simulation src/open_vins/config/rpng_sim/estimator_config.yaml"

--- a/Dockerfile_ros2_24_04
+++ b/Dockerfile_ros2_24_04
@@ -1,0 +1,46 @@
+FROM osrf/ros:jazzy-desktop
+
+# =========================================================
+# =========================================================
+
+# Are you are looking for how to use this docker file?
+#   - https://docs.openvins.com/dev-docker.html
+#   - https://docs.docker.com/get-started/
+#   - http://wiki.ros.org/docker/Tutorials/Docker
+
+# =========================================================
+# =========================================================
+
+# Dependencies we use, catkin tools is very good build system
+# Also some helper utilities for fast in terminal edits (nano etc)
+RUN apt-get update && apt-get install -y libeigen3-dev nano git sudo
+
+# Ceres solver install and setup
+RUN apt-get update && apt-get install -y cmake libgoogle-glog-dev libgflags-dev libatlas-base-dev libeigen3-dev libsuitesparse-dev libceres-dev
+# ENV CERES_VERSION="2.2.0"
+# RUN git clone https://ceres-solver.googlesource.com/ceres-solver && \
+#     cd ceres-solver && \
+#     git checkout tags/${CERES_VERSION} && \
+#     mkdir build && cd build && \
+#     cmake .. && \
+#     make -j$(nproc) install && \
+#     rm -rf ../../ceres-solver
+
+# Seems this has Python 3.12 installed on it...
+RUN apt-get update && apt-get install -y python3-dev python3-matplotlib python3-numpy python3-psutil python3-tk
+
+# Install deps needed for clion remote debugging
+# https://blog.jetbrains.com/clion/2020/01/using-docker-with-clion/
+# RUN sed -i '6i\source "/catkin_ws/install/setup.bash"\' /ros_entrypoint.sh
+RUN apt-get update && apt-get install -y ssh build-essential gcc g++ \
+    gdb clang cmake rsync tar python3 && apt-get clean
+RUN ( \
+    echo 'LogLevel DEBUG2'; \
+    echo 'PermitRootLogin yes'; \
+    echo 'PasswordAuthentication yes'; \
+    echo 'Subsystem sftp /usr/lib/openssh/sftp-server'; \
+  ) > /etc/ssh/sshd_config_test_clion \
+  && mkdir /run/sshd
+RUN useradd -m user && yes password | passwd user
+RUN usermod -s /bin/bash user
+CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config_test_clion"]

--- a/ov_core/CMakeLists.txt
+++ b/ov_core/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ov_core)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
 # The OpenCV version needs to match the one used by cv_bridge otherwise you will get a segmentation fault!
-find_package(Eigen3 3.4.0 REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(OpenCV 3 QUIET)
 if (NOT OpenCV_FOUND)
     find_package(OpenCV 4 REQUIRED)

--- a/ov_core/CMakeLists.txt
+++ b/ov_core/CMakeLists.txt
@@ -3,13 +3,13 @@ project(ov_core)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
 # The OpenCV version needs to match the one used by cv_bridge otherwise you will get a segmentation fault!
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 3.4.0 REQUIRED)
 find_package(OpenCV 3 QUIET)
 if (NOT OpenCV_FOUND)
     find_package(OpenCV 4 REQUIRED)
 endif ()
 find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
-message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION})
+message(STATUS "EIGEN: " ${Eigen3_VERSION} " | OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION})
 
 # By default we build with ROS, but you can disable this and just build as a library
 option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)

--- a/ov_core/cmake/ROS1.cmake
+++ b/ov_core/cmake/ROS1.cmake
@@ -23,7 +23,7 @@ endif ()
 # Include our header files
 include_directories(
         src
-        ${EIGEN3_INCLUDE_DIR}
+        ${EIGEN3_INCLUDE_DIRS}
         ${Boost_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}
 )

--- a/ov_core/cmake/ROS1.cmake
+++ b/ov_core/cmake/ROS1.cmake
@@ -24,6 +24,7 @@ endif ()
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}
 )

--- a/ov_core/cmake/ROS2.cmake
+++ b/ov_core/cmake/ROS2.cmake
@@ -15,7 +15,7 @@ add_definitions(-DROS_AVAILABLE=2)
 # Include our header files
 include_directories(
         src
-        ${EIGEN3_INCLUDE_DIR}
+        ${EIGEN3_INCLUDE_DIRS}
         ${Boost_INCLUDE_DIRS}
 )
 

--- a/ov_core/cmake/ROS2.cmake
+++ b/ov_core/cmake/ROS2.cmake
@@ -16,6 +16,7 @@ add_definitions(-DROS_AVAILABLE=2)
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
 )
 

--- a/ov_eval/CMakeLists.txt
+++ b/ov_eval/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.3)
 project(ov_eval)
 
 # Include libraries
-find_package(Eigen3 3.4.0 REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 message(STATUS "EIGEN: " ${Eigen3_VERSION} " | BOOST: " ${Boost_VERSION})
 

--- a/ov_eval/CMakeLists.txt
+++ b/ov_eval/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.3)
 project(ov_eval)
 
 # Include libraries
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 3.4.0 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
+message(STATUS "EIGEN: " ${Eigen3_VERSION} " | BOOST: " ${Boost_VERSION})
 
 # By default we build with ROS, but you can disable this and just build as a library
 option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)

--- a/ov_eval/cmake/ROS1.cmake
+++ b/ov_eval/cmake/ROS1.cmake
@@ -23,7 +23,7 @@ endif ()
 # Include our header files
 include_directories(
         src
-        ${EIGEN3_INCLUDE_DIR}
+        ${EIGEN3_INCLUDE_DIRS}
         ${Boost_INCLUDE_DIRS}
         ${PYTHON_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}

--- a/ov_eval/cmake/ROS1.cmake
+++ b/ov_eval/cmake/ROS1.cmake
@@ -24,6 +24,7 @@ endif ()
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
         ${PYTHON_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}

--- a/ov_eval/cmake/ROS2.cmake
+++ b/ov_eval/cmake/ROS2.cmake
@@ -15,7 +15,7 @@ add_definitions(-DROS_AVAILABLE=2)
 # Include our header files
 include_directories(
         src
-        ${EIGEN3_INCLUDE_DIR}
+        ${EIGEN3_INCLUDE_DIRS}
         ${Boost_INCLUDE_DIRS}
         ${PYTHON_INCLUDE_DIRS}
 )

--- a/ov_eval/cmake/ROS2.cmake
+++ b/ov_eval/cmake/ROS2.cmake
@@ -16,6 +16,7 @@ add_definitions(-DROS_AVAILABLE=2)
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
         ${PYTHON_INCLUDE_DIRS}
 )

--- a/ov_init/CMakeLists.txt
+++ b/ov_init/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ov_init)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
 # The OpenCV version needs to match the one used by cv_bridge otherwise you will get a segmentation fault!
-find_package(Eigen3 3.4.0 REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(OpenCV 3 QUIET)
 if (NOT OpenCV_FOUND)
     find_package(OpenCV 4 REQUIRED)

--- a/ov_init/CMakeLists.txt
+++ b/ov_init/CMakeLists.txt
@@ -4,14 +4,14 @@ project(ov_init)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
 # The OpenCV version needs to match the one used by cv_bridge otherwise you will get a segmentation fault!
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 3.4.0 REQUIRED)
 find_package(OpenCV 3 QUIET)
 if (NOT OpenCV_FOUND)
     find_package(OpenCV 4 REQUIRED)
 endif ()
 find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 find_package(Ceres REQUIRED)
-message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION} " | CERES: " ${Ceres_VERSION})
+message(STATUS "EIGEN: " ${Eigen3_VERSION} " | OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION} " | CERES: " ${Ceres_VERSION})
 
 # By default we build with ROS, but you can disable this and just build as a library
 option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)

--- a/ov_init/cmake/ROS1.cmake
+++ b/ov_init/cmake/ROS1.cmake
@@ -23,7 +23,7 @@ endif ()
 # Include our header files
 include_directories(
         src
-        ${EIGEN3_INCLUDE_DIR}
+        ${EIGEN3_INCLUDE_DIRS}
         ${Boost_INCLUDE_DIRS}
         ${CERES_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}

--- a/ov_init/cmake/ROS1.cmake
+++ b/ov_init/cmake/ROS1.cmake
@@ -24,6 +24,7 @@ endif ()
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
         ${CERES_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}

--- a/ov_init/cmake/ROS2.cmake
+++ b/ov_init/cmake/ROS2.cmake
@@ -16,7 +16,7 @@ add_definitions(-DROS_AVAILABLE=2)
 # Include our header files
 include_directories(
         src
-        ${EIGEN3_INCLUDE_DIR}
+        ${EIGEN3_INCLUDE_DIRS}
         ${Boost_INCLUDE_DIRS}
         ${CERES_INCLUDE_DIRS}
 )

--- a/ov_init/cmake/ROS2.cmake
+++ b/ov_init/cmake/ROS2.cmake
@@ -17,6 +17,7 @@ add_definitions(-DROS_AVAILABLE=2)
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
         ${CERES_INCLUDE_DIRS}
 )

--- a/ov_msckf/CMakeLists.txt
+++ b/ov_msckf/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ov_msckf)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
 # The OpenCV version needs to match the one used by cv_bridge otherwise you will get a segmentation fault!
-find_package(Eigen3 3.4.0 REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(OpenCV 3 QUIET)
 if (NOT OpenCV_FOUND)
     find_package(OpenCV 4 REQUIRED)

--- a/ov_msckf/CMakeLists.txt
+++ b/ov_msckf/CMakeLists.txt
@@ -3,14 +3,14 @@ project(ov_msckf)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
 # The OpenCV version needs to match the one used by cv_bridge otherwise you will get a segmentation fault!
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 3.4.0 REQUIRED)
 find_package(OpenCV 3 QUIET)
 if (NOT OpenCV_FOUND)
     find_package(OpenCV 4 REQUIRED)
 endif ()
 find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 find_package(Ceres REQUIRED)
-message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION} " | CERES: " ${Ceres_VERSION})
+message(STATUS "EIGEN: " ${Eigen3_VERSION} " | OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION} " | CERES: " ${Ceres_VERSION})
 
 # By default we build with ROS, but you can disable this and just build as a library
 option(ENABLE_ROS "Enable or disable building with ROS (if it is found)" ON)

--- a/ov_msckf/cmake/ROS1.cmake
+++ b/ov_msckf/cmake/ROS1.cmake
@@ -25,6 +25,7 @@ endif ()
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
         ${CERES_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}

--- a/ov_msckf/cmake/ROS1.cmake
+++ b/ov_msckf/cmake/ROS1.cmake
@@ -24,7 +24,7 @@ endif ()
 # Include our header files
 include_directories(
         src
-        ${EIGEN3_INCLUDE_DIR}
+        ${EIGEN3_INCLUDE_DIRS}
         ${Boost_INCLUDE_DIRS}
         ${CERES_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}

--- a/ov_msckf/cmake/ROS2.cmake
+++ b/ov_msckf/cmake/ROS2.cmake
@@ -24,7 +24,7 @@ add_definitions(-DROS_AVAILABLE=2)
 # Include our header files
 include_directories(
         src
-        ${EIGEN3_INCLUDE_DIR}
+        ${EIGEN3_INCLUDE_DIRS}
         ${Boost_INCLUDE_DIRS}
         ${CERES_INCLUDE_DIRS}
 )

--- a/ov_msckf/cmake/ROS2.cmake
+++ b/ov_msckf/cmake/ROS2.cmake
@@ -25,6 +25,7 @@ add_definitions(-DROS_AVAILABLE=2)
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
         ${CERES_INCLUDE_DIRS}
 )

--- a/ov_msckf/src/ros/ROS2Visualizer.cpp
+++ b/ov_msckf/src/ros/ROS2Visualizer.cpp
@@ -36,7 +36,7 @@ using namespace ov_type;
 using namespace ov_msckf;
 
 ROS2Visualizer::ROS2Visualizer(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<VioManager> app, std::shared_ptr<Simulator> sim)
-    : _node(node), _app(app), _sim(sim), thread_update_running(false) {
+    : _node(node), _app(app), _sim(sim), thread_update_running(false), run_visualize_thread(true) {
 
   // Setup our transform broadcaster
   mTfBr = std::make_shared<tf2_ros::TransformBroadcaster>(node);
@@ -149,15 +149,48 @@ ROS2Visualizer::ROS2Visualizer(std::shared_ptr<rclcpp::Node> node, std::shared_p
 
   // Start thread for the image publishing
   if (_app->get_params().use_multi_threading_pubs) {
-    std::thread thread([&] {
+    thread_visualize = std::make_shared<std::thread>([this] {
       rclcpp::Rate loop_rate(20);
-      while (rclcpp::ok()) {
+      while (rclcpp::ok() && run_visualize_thread) {
         publish_images();
         loop_rate.sleep();
       }
     });
-    thread.detach();
   }
+}
+
+ROS2Visualizer::~ROS2Visualizer() {
+  // Signal and join the visualize thread
+  run_visualize_thread = false;
+  if (thread_visualize && thread_visualize->joinable()) {
+    thread_visualize->join();
+  }
+
+  // Manually reset all publishers and subscriptions
+  it_pub_tracks.shutdown();
+  it_pub_loop_img_depth.shutdown();
+  it_pub_loop_img_depth_color.shutdown();
+  pub_poseimu.reset();
+  pub_odomimu.reset();
+  pub_pathimu.reset();
+  pub_points_msckf.reset();
+  pub_points_slam.reset();
+  pub_points_aruco.reset();
+  pub_points_sim.reset();
+  pub_loop_pose.reset();
+  pub_loop_extrinsic.reset();
+  pub_loop_point.reset();
+  pub_loop_intrinsics.reset();
+  mTfBr.reset();
+  sub_imu.reset();
+  for (auto &sub : subs_cam)
+    sub.reset();
+  for (auto &sync : sync_cam)
+    sync.reset();
+  for (auto &sub : sync_subs_cam)
+    sub.reset();
+  pub_pathgt.reset();
+  pub_posegt.reset();
 }
 
 void ROS2Visualizer::setup_subscribers(std::shared_ptr<ov_core::YamlParser> parser) {

--- a/ov_msckf/src/ros/ROS2Visualizer.h
+++ b/ov_msckf/src/ros/ROS2Visualizer.h
@@ -25,7 +25,13 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+
+#if __has_include(<image_transport/image_transport.hpp>)
+#include <image_transport/image_transport.hpp>
+#else
 #include <image_transport/image_transport.h>
+#endif
+
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/time_synchronizer.h>
@@ -42,7 +48,13 @@
 #include <std_msgs/msg/float64.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/transform_datatypes.h>
+
+#if __has_include(<tf2_geometry_msgs/tf2_geometry_msgs.hpp>)
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#endif
+
 #include <tf2_ros/transform_broadcaster.h>
 
 #include <atomic>
@@ -53,7 +65,13 @@
 #include <Eigen/Eigen>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/filesystem.hpp>
+
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
+
 
 namespace ov_core {
 class YamlParser;

--- a/ov_msckf/src/ros/ROS2Visualizer.h
+++ b/ov_msckf/src/ros/ROS2Visualizer.h
@@ -105,6 +105,11 @@ public:
   ROS2Visualizer(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<VioManager> app, std::shared_ptr<Simulator> sim = nullptr);
 
   /**
+   * @brief Destructor to ensure proper cleanup of ROS 2 resources
+   */
+  ~ROS2Visualizer();
+
+  /**
    * @brief Will setup ROS subscribers and callbacks
    * @param parser Configuration file parser
    */
@@ -198,6 +203,8 @@ protected:
 
   // Thread atomics
   std::atomic<bool> thread_update_running;
+  std::atomic<bool> run_visualize_thread;
+  std::shared_ptr<std::thread> thread_visualize;
 
   /// Queue up camera measurements sorted by time and trigger once we have
   /// exactly one IMU measurement with timestamp newer than the camera measurement

--- a/ov_msckf/src/ros/ROSVisualizerHelper.h
+++ b/ov_msckf/src/ros/ROSVisualizerHelper.h
@@ -34,9 +34,14 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <tf2/transform_datatypes.h>
+
+#if __has_include(<tf2_geometry_msgs/tf2_geometry_msgs.hpp>)
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #endif
 
+#endif
 namespace ov_type {
 class PoseJPL;
 }

--- a/ov_msckf/src/run_simulation.cpp
+++ b/ov_msckf/src/run_simulation.cpp
@@ -180,9 +180,15 @@ int main(int argc, char **argv) {
   // Final visualization
 #if ROS_AVAILABLE == 1
   viz->visualize_final();
+  viz.reset();
+  sys.reset();
+  sim.reset();
   ros::shutdown();
 #elif ROS_AVAILABLE == 2
   viz->visualize_final();
+  viz.reset();
+  sys.reset();
+  sim.reset();
   rclcpp::shutdown();
 #endif
 

--- a/ov_msckf/src/run_subscribe_msckf.cpp
+++ b/ov_msckf/src/run_subscribe_msckf.cpp
@@ -115,8 +115,12 @@ int main(int argc, char **argv) {
   // Final visualization
   viz->visualize_final();
 #if ROS_AVAILABLE == 1
+  viz.reset();
+  sys.reset();
   ros::shutdown();
 #elif ROS_AVAILABLE == 2
+  viz.reset();
+  sys.reset();
   rclcpp::shutdown();
 #endif
 

--- a/ov_msckf/src/update/UpdaterHelper.cpp
+++ b/ov_msckf/src/update/UpdaterHelper.cpp
@@ -367,14 +367,14 @@ void UpdaterHelper::get_feature_jacobian_full(std::shared_ptr<State> state, Upda
       state->_cam_intrinsics_cameras.at(pair.first)->compute_distort_jacobian(uv_norm, dz_dzn, dz_dzeta);
 
       // Normalized coordinates in respect to projection function
-      Eigen::MatrixXd dzn_dpfc = Eigen::MatrixXd::Zero(2, 3);
+      Eigen::Matrix<double, 2, 3> dzn_dpfc = Eigen::Matrix<double, 2, 3>::Zero();
       dzn_dpfc << 1 / p_FinCi(2), 0, -p_FinCi(0) / (p_FinCi(2) * p_FinCi(2)), 0, 1 / p_FinCi(2), -p_FinCi(1) / (p_FinCi(2) * p_FinCi(2));
 
       // Derivative of p_FinCi in respect to p_FinIi
-      Eigen::MatrixXd dpfc_dpfg = R_ItoC * R_GtoIi;
+      Eigen::Matrix3d dpfc_dpfg = R_ItoC * R_GtoIi;
 
       // Derivative of p_FinCi in respect to camera clone state
-      Eigen::MatrixXd dpfc_dclone = Eigen::MatrixXd::Zero(3, 6);
+      Eigen::Matrix<double, 3, 6> dpfc_dclone = Eigen::Matrix<double, 3, 6>::Zero();
       dpfc_dclone.block(0, 0, 3, 3).noalias() = R_ItoC * skew_x(p_FinIi);
       dpfc_dclone.block(0, 3, 3, 3) = -dpfc_dpfg;
 
@@ -382,8 +382,8 @@ void UpdaterHelper::get_feature_jacobian_full(std::shared_ptr<State> state, Upda
       //=========================================================================
 
       // Precompute some matrices
-      Eigen::MatrixXd dz_dpfc = dz_dzn * dzn_dpfc;
-      Eigen::MatrixXd dz_dpfg = dz_dpfc * dpfc_dpfg;
+      Eigen::Matrix<double, 2, 3> dz_dpfc = dz_dzn * dzn_dpfc;
+      Eigen::Matrix<double, 2, 3> dz_dpfg = dz_dpfc * dpfc_dpfg;
 
       // CHAINRULE: get the total feature Jacobian
       H_f.block(2 * c, 0, 2, H_f.cols()).noalias() = dz_dpfg * dpfg_dlambda;
@@ -404,7 +404,7 @@ void UpdaterHelper::get_feature_jacobian_full(std::shared_ptr<State> state, Upda
       if (state->_options.do_calib_camera_pose) {
 
         // Calculate the Jacobian
-        Eigen::MatrixXd dpfc_dcalib = Eigen::MatrixXd::Zero(3, 6);
+        Eigen::Matrix<double, 3, 6> dpfc_dcalib = Eigen::Matrix<double, 3, 6>::Zero();
         dpfc_dcalib.block(0, 0, 3, 3) = skew_x(p_FinCi - p_IinC);
         dpfc_dcalib.block(0, 3, 3, 3) = Eigen::Matrix<double, 3, 3>::Identity();
 


### PR DESCRIPTION
- Addressed segmentation faults caused by the latest Ceres version on Ubuntu 24.04
- Added support for ROS2 Jazzy by fixing header includes and adjustments in the ros2visualizer module
- config files D455 Stereo Mode: Using stereo IR streams + IMU.
- config files D455 Mono Mode: Using mono RGB + IMU.
![image](https://github.com/user-attachments/assets/4ebb3d12-3797-4657-aa56-bac9157e61e1)
