### PR TITLE
Add dynamic masking support and VIODE dataset configuration

### DIFF
--- a/config/euroc_mav/estimator_config.yaml
+++ b/config/euroc_mav/estimator_config.yaml
@@ -124,10 +124,6 @@ use_imu_residual: false
 imu_residual_alpha: 5.0
 imu_residual_sigma_px: 5.0
 
-# Phase 2 JEPA dataset collection — disabled by default, zero runtime cost when false.
-log_features: false
-log_features_path: ""
-
 
 
 

--- a/config/kaist_urban/estimator_config.yaml
+++ b/config/kaist_urban/estimator_config.yaml
@@ -1,54 +1,60 @@
 %YAML:1.0 # need to specify the file type at the top!
 
+# KAIST Complex Urban Dataset (urban28/32/38/39 ...).
+# Point Grey Flea3 stereo (1280x560 @ ~10Hz, baseline ~0.48m) + Xsens MTi-300 IMU (100Hz).
+# Bag produced by convert_kaist_to_ros2bag.py — images already undistorted+rectified.
+# Ground vehicle, mostly-planar motion → same "degenerate motion" caveats as config/kaist_vio.
+
 verbosity: "INFO" # ALL, DEBUG, INFO, WARNING, ERROR, SILENT
 
-use_fej: true # if first-estimate Jacobians should be used (enable for good consistency)
-integration: "rk4" # discrete, rk4, analytical (if rk4 or analytical used then analytical covariance propagation is used)
-use_stereo: true # if we have more than 1 camera, if we should try to track stereo constraints
-max_cameras: 2 # how many cameras we have 1 = mono, 2 = stereo, >2 = binocular (all mono tracking)
+use_fej: true
+integration: "rk4"
+use_stereo: true # NEED TO USE STEREO! OTHERWISE CAN'T RECOVER SCALE!!!!!! DEGENERATE MOTION!!!
+max_cameras: 2
 
-calib_cam_extrinsics: true
+calib_cam_extrinsics: false # disable, planar vehicle motion is degenerate for online extrinsic calib
 calib_cam_intrinsics: true
-calib_cam_timeoffset: true
+calib_cam_timeoffset: false # disable, same degenerate-motion reasoning
 calib_imu_intrinsics: false
 calib_imu_g_sensitivity: false
 
 max_clones: 11
 max_slam: 50
 max_slam_in_update: 25
-max_msckf_in_update: 40
-dt_slam_delay: 2
+max_msckf_in_update: 50
+dt_slam_delay: 1
 
-gravity_mag: 9.80766
+gravity_mag: 9.81
 
 feat_rep_msckf: "GLOBAL_3D"
 feat_rep_slam: "ANCHORED_MSCKF_INVERSE_DEPTH"
 feat_rep_aruco: "ANCHORED_MSCKF_INVERSE_DEPTH"
 
 # zero velocity update parameters we can use
-# we support either IMU-based or disparity detection.
 try_zupt: false
-zupt_chi2_multipler: 0 # set to 0 for only disp-based
+zupt_chi2_multipler: 0
 zupt_max_velocity: 0.1
 zupt_noise_multiplier: 50
-zupt_max_disparity: 2.0 # set to 0 for only imu-based
+zupt_max_disparity: 2.0
 zupt_only_at_beginning: true
 
 # ==================================================================
 # ==================================================================
 
-init_window_time: 2.0 # make 2sec if using dynamic...
-init_imu_thresh: 0.45 # room1-5:0.45, room6:0.25
-init_max_disparity: 15.0
-init_max_features: 50
+init_window_time: 2.0
+init_imu_thresh: 0.60
+init_max_disparity: 5.0
+init_max_features: 100 # was 50 — debug run on urban39 0-30s saw only 22-37 valid (need ~48)
 
+# Driving sequences essentially never start from a stationary rest period like
+# the TUM-VI/EuRoC handheld captures do — use dynamic (motion) initialization.
 init_dyn_use: true
 init_dyn_mle_opt_calib: false
 init_dyn_mle_max_iter: 50
 init_dyn_mle_max_time: 0.05
 init_dyn_mle_max_threads: 6
 init_dyn_num_pose: 6
-init_dyn_min_deg: 10.0
+init_dyn_min_deg: 3.0 # was 10.0 — straight-driving segments only see 2-6 deg gyro change; stereo recovers scale without needing large rotation
 
 init_dyn_inflation_ori: 10
 init_dyn_inflation_vel: 100
@@ -74,21 +80,23 @@ filepath_gt: "/tmp/ov_groundtruth.txt"
 # ==================================================================
 
 # our front-end feature tracking parameters
-# we have a KLT and descriptor based (KLT is better implemented...)
 use_klt: true
-num_pts: 200
-fast_threshold: 20
-grid_x: 5
+num_pts: 600 # was 400 — more candidates to help clear init_max_features requirement
+fast_threshold: 15 # was 20 — slightly looser corner detection for more candidates
+grid_x: 10  # wide 1280x560 image (2.3:1 aspect) -> more columns than rows to keep cells ~square
 grid_y: 5
-min_px_dist: 15
-knn_ratio: 0.65
-track_frequency: 21.0
+min_px_dist: 25 # scaled up vs kaist_vio's 15 since resolution is ~2x (1280 vs 640 wide)
+knn_ratio: 0.70
+track_frequency: 10.0 # camera is only ~10Hz, no point asking for more
 downsample_cameras: false
-num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
-histogram_method: "HISTOGRAM" # NONE, HISTOGRAM, CLAHE
+num_opencv_threads: 4
+histogram_method: "HISTOGRAM"
+
+fi_max_dist: 10.0
+fi_max_baseline: 200
+fi_max_cond_number: 25000
 
 # aruco tag tracker for the system
-# DICT_6X6_1000 from https://chev.me/arucogen/
 use_aruco: false
 num_aruco: 1024
 downsize_aruco: true
@@ -96,25 +104,21 @@ downsize_aruco: true
 # ==================================================================
 # ==================================================================
 
-# camera noises and chi-squared threshold multipliers
-up_msckf_sigma_px: 1
+up_msckf_sigma_px: 1.2
 up_msckf_chi2_multipler: 1
-up_slam_sigma_px: 1
+up_slam_sigma_px: 1.2
 up_slam_chi2_multipler: 1
 up_aruco_sigma_px: 1
 up_aruco_chi2_multipler: 1
 
 # masks for our images
-use_mask: true
-mask0: "mask_tumvi0.png" #relative to current file
-mask1: "mask_tumvi1.png" #relative to current file
+use_mask: false
 
 # imu and camera spacial-temporal
-# imu config should also have the correct noise values
 relative_config_imu: "kalibr_imu_chain.yaml"
 relative_config_imucam: "kalibr_imucam_chain.yaml"
 
-# Dynamic mask — not used for TUM-VI (no segmentation masks available)
+# Dynamic mask — not used for KAIST (no segmentation masks available)
 use_dynamic_mask: false
 dynamic_mask_topic0: "/cam0/masked"
 dynamic_mask_topic1: "/cam1/masked"
@@ -127,6 +131,3 @@ imu_residual_sigma_px: 5.0
 # Phase 2 JEPA dataset collection
 log_features: false
 log_features_path: ""
-
-
-

--- a/config/kaist_urban/estimator_config.yaml
+++ b/config/kaist_urban/estimator_config.yaml
@@ -127,7 +127,3 @@ dynamic_mask_topic1: "/cam1/masked"
 use_imu_residual: false
 imu_residual_alpha: 5.0
 imu_residual_sigma_px: 5.0
-
-# Phase 2 JEPA dataset collection
-log_features: false
-log_features_path: ""

--- a/config/kaist_urban/estimator_config_imu_residual.yaml
+++ b/config/kaist_urban/estimator_config_imu_residual.yaml
@@ -1,10 +1,8 @@
 %YAML:1.0 # need to specify the file type at the top!
 
-# KAIST Complex Urban Dataset (urban38/urban39).
-# Point Grey Flea3 stereo (1280x560 @ ~10Hz, baseline ~0.48m) + Xsens MTi-300 IMU (100Hz).
-# Bags produced by convert_kaist_to_ros2bag.py — raw images (no pre-rectification).
-# Parameter values copied from config/kaist/ (official OpenVINS KAIST config),
-# adapted for our dynamic-mask evaluation setup.
+# KAIST Complex Urban — IMU-residual variant.
+# Identical to estimator_config.yaml (based on official kaist/ config values)
+# except use_imu_residual: true with VIODE-proven params (alpha=1.5, sigma=10, delay=5).
 
 verbosity: "INFO"
 
@@ -31,7 +29,6 @@ feat_rep_msckf: "ANCHORED_MSCKF_INVERSE_DEPTH"
 feat_rep_slam: "ANCHORED_MSCKF_INVERSE_DEPTH"
 feat_rep_aruco: "ANCHORED_MSCKF_INVERSE_DEPTH"
 
-# ZUPT: urban driving has stop lights — zero-velocity updates during stops reduce bias drift
 try_zupt: true
 zupt_chi2_multipler: 0.5
 zupt_max_velocity: 0.1
@@ -91,7 +88,7 @@ num_opencv_threads: 4
 histogram_method: "HISTOGRAM"
 
 fi_min_dist: 0.25
-fi_max_dist: 150.0        # urban features at 20-150m; was 10.0 (rejected almost everything)
+fi_max_dist: 150.0
 fi_max_baseline: 200
 fi_max_cond_number: 20000
 fi_triangulate_1d: false
@@ -115,13 +112,12 @@ use_mask: false
 relative_config_imu: "kalibr_imu_chain.yaml"
 relative_config_imucam: "kalibr_imucam_chain.yaml"
 
-# Dynamic mask: always true — yolo_masker runs with force_empty for unmasked/imu_only.
-# Input topics are remapped to KAIST stereo topics at launch time.
 use_dynamic_mask: true
 dynamic_mask_topic0: "/cam0/masked"
 dynamic_mask_topic1: "/cam1/masked"
 
-use_imu_residual: false
+# IMU-residual active — same params as VIODE batch_7 best config
+use_imu_residual: true
 imu_residual_alpha: 1.5
 imu_residual_sigma_px: 10.0
 use_residual_variance: false

--- a/config/kaist_urban/kalibr_imu_chain.yaml
+++ b/config/kaist_urban/kalibr_imu_chain.yaml
@@ -1,0 +1,37 @@
+%YAML:1.0 # need to specify the file type at the top!
+
+imu0:
+  T_i_b:
+    - [1.0, 0.0, 0.0, 0.0]
+    - [0.0, 1.0, 0.0, 0.0]
+    - [0.0, 0.0, 1.0, 0.0]
+    - [0.0, 0.0, 0.0, 1.0]
+  # Approximate Xsens MTi-300 datasheet values (no per-unit calibration available) — tune if filter diverges.
+  accelerometer_noise_density: 0.01   # [ m / s^2 / sqrt(Hz) ]
+  accelerometer_random_walk: 0.001    # [ m / s^3 / sqrt(Hz) ]
+  gyroscope_noise_density: 0.001      # [ rad / s / sqrt(Hz) ]
+  gyroscope_random_walk: 0.0001       # [ rad / s^2 / sqrt(Hz) ]
+  rostopic: /imu0
+  time_offset: 0.0
+  update_rate: 100.0
+  model: "kalibr"
+  Tw:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  R_IMUtoGYRO:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  Ta:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  R_IMUtoACC:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  Tg:
+    - [ 0.0, 0.0, 0.0 ]
+    - [ 0.0, 0.0, 0.0 ]
+    - [ 0.0, 0.0, 0.0 ]

--- a/config/kaist_urban/kalibr_imu_chain.yaml
+++ b/config/kaist_urban/kalibr_imu_chain.yaml
@@ -12,7 +12,7 @@ imu0:
   gyroscope_random_walk: 1.0000e-05        # [ rad / s^2 / sqrt(Hz) ]
   rostopic: /imu0
   time_offset: 0.0
-  update_rate: 500.0
+  update_rate: 100.0  # Xsens MTi-300 actual publish rate (was 500.0 — incorrect)
   model: "kalibr"
   Tw:
     - [ 1.0, 0.0, 0.0 ]

--- a/config/kaist_urban/kalibr_imu_chain.yaml
+++ b/config/kaist_urban/kalibr_imu_chain.yaml
@@ -6,14 +6,13 @@ imu0:
     - [0.0, 1.0, 0.0, 0.0]
     - [0.0, 0.0, 1.0, 0.0]
     - [0.0, 0.0, 0.0, 1.0]
-  # Approximate Xsens MTi-300 datasheet values (no per-unit calibration available) — tune if filter diverges.
-  accelerometer_noise_density: 0.01   # [ m / s^2 / sqrt(Hz) ]
-  accelerometer_random_walk: 0.001    # [ m / s^3 / sqrt(Hz) ]
-  gyroscope_noise_density: 0.001      # [ rad / s / sqrt(Hz) ]
-  gyroscope_random_walk: 0.0001       # [ rad / s^2 / sqrt(Hz) ]
+  accelerometer_noise_density: 5.8860e-03  # [ m / s^2 / sqrt(Hz) ]
+  accelerometer_random_walk: 1.0000e-04    # [ m / s^3 / sqrt(Hz) ]
+  gyroscope_noise_density: 1.7453e-04      # [ rad / s / sqrt(Hz) ]
+  gyroscope_random_walk: 1.0000e-05        # [ rad / s^2 / sqrt(Hz) ]
   rostopic: /imu0
   time_offset: 0.0
-  update_rate: 100.0
+  update_rate: 500.0
   model: "kalibr"
   Tw:
     - [ 1.0, 0.0, 0.0 ]

--- a/config/kaist_urban/kalibr_imucam_chain.yaml
+++ b/config/kaist_urban/kalibr_imucam_chain.yaml
@@ -1,113 +1,29 @@
 %YAML:1.0 # need to specify the file type at the top!
 
-# KAIST Complex Urban Dataset (urban28/32/38/39 ...), Point Grey Flea3 stereo + Xsens MTi-300.
-# NOT the same hardware as config/kaist_vio (that one is a RealSense D435 + MAVROS testbed).
-#
-# Extrinsics derived from the dataset's calibration/Vehicle2Stereo.txt and Vehicle2IMU.txt.
-# IMPORTANT: those files describe sensor POSE *IN* the vehicle frame
-# (p_vehicle = R @ p_sensor + T), NOT a vehicle->sensor transform. So:
-#   R_ItoC = R_Vehicle2Stereo.T
-#   p_IinC = R_Vehicle2Stereo.T @ (T_Vehicle2IMU - T_Vehicle2Stereo)
-# Verified by cross-checking against rpng/kaist2bag's independently-calibrated
-# reference values for this exact rig (same camera model/resolution) — the
-# corrected formula matches to ~5 decimal places; the original (un-transposed)
-# version was off by a full rotation inversion and caused immediate EKF
-# divergence (position blew up to 100s of km within seconds of init).
-# Then rotated into the RECTIFIED camera frame (since convert_kaist_to_ros2bag.py
-# undistorts+rectifies images before writing them to the bag).
-# Intrinsics are the post-rectification projection_matrix values from left.yaml/right.yaml
-# (distortion is zero because images are already undistorted by the converter).
-# Values are identical between urban38-pankyo and urban39-pankyo (same calibration
-# session), so this single file covers both sequences.
-
 cam0:
-  T_cam_imu:
-    - - -0.01420717220
-      - -0.99989908800
-      - -0.00057390980
-      - 0.27163774000
-    - - -0.01360966850
-      - 0.00076729004
-      - -0.99990752700
-      - -0.09276405000
-    - - 0.99979698500
-      - -0.01419811180
-      - -0.01361915480
-      - -1.71010806000
-    - - 0.0
-      - 0.0
-      - 0.0
-      - 1.0
-  cam_overlaps:
-    - 1
+  T_imu_cam: #rotation from camera to IMU R_CtoI, position of camera in IMU p_CinI
+    - [-0.00681,-0.01532,0.99987,1.71239]
+    - [-0.99998,0.00033,-0.00680,0.24740]
+    - [-0.00023,-0.99988,-0.01532,-0.11589]
+    - [0.0, 0.0, 0.0, 1.0]
+  cam_overlaps: [1]
   camera_model: pinhole
-  distortion_coeffs:
-    - 0.0
-    - 0.0
-    - 0.0
-    - 0.0
+  distortion_coeffs: [-5.6143027800000002e-02,1.3952563200000001e-01,-1.2155906999999999e-03,-9.7281389999999998e-04]
   distortion_model: radtan
-  intrinsics:
-    - 781.35803072
-    - 781.35803072
-    - 617.96599579
-    - 263.54596138
-  resolution:
-    - 1280
-    - 560
-  rostopic: /stereo/left/image_rect
-  timeshift_cam_imu: 0.0
+  intrinsics: [8.1690378992770002e+02,8.1156803828490001e+02,6.0850726281690004e+02,2.6347599764440002e+02]
+  resolution: [1280, 560]
+  rostopic: /stereo/left/image_raw
+
 cam1:
-  T_cam_imu:
-    - - -0.01420717220
-      - -0.99989908800
-      - -0.00057390980
-      - -0.20989365000
-    - - -0.01360966850
-      - 0.00076729004
-      - -0.99990752700
-      - -0.09276405000
-    - - 0.99979698500
-      - -0.01419811180
-      - -0.01361915480
-      - -1.71010806000
-    - - 0.0
-      - 0.0
-      - 0.0
-      - 1.0
-  T_cn_cnm1:
-    - - 1.0
-      - 0.0
-      - 0.0
-      - -0.48153139391
-    - - 0.0
-      - 1.0
-      - 0.0
-      - 0.0
-    - - 0.0
-      - 0.0
-      - 1.0
-      - 0.0
-    - - 0.0
-      - 0.0
-      - 0.0
-      - 1.0
-  cam_overlaps:
-    - 0
+  T_imu_cam: #rotation from camera to IMU R_CtoI, position of camera in IMU p_CinI
+    - [-0.01036,-0.01075,0.99990,1.70544]
+    - [-0.99994,-0.00178,-0.01038,-0.22770]
+    - [0.00189,-0.99994,-0.01073,-0.11611]
+    - [0.0, 0.0, 0.0, 1.0]
+  cam_overlaps: [0]
   camera_model: pinhole
-  distortion_coeffs:
-    - 0.0
-    - 0.0
-    - 0.0
-    - 0.0
+  distortion_coeffs: [-5.4921981799999998e-02,1.4243657430000001e-01,7.5412299999999996e-05,-6.7560530000000001e-04]
   distortion_model: radtan
-  intrinsics:
-    - 781.35803072
-    - 781.35803072
-    - 617.96599579
-    - 263.54596138
-  resolution:
-    - 1280
-    - 560
-  rostopic: /stereo/right/image_rect
-  timeshift_cam_imu: 0.0
+  intrinsics: [8.1378205539589999e+02,8.0852165574269998e+02,6.1386419539320002e+02,2.4941049348650000e+02]
+  resolution: [1280, 560]
+  rostopic: /stereo/right/image_raw

--- a/config/kaist_urban/kalibr_imucam_chain.yaml
+++ b/config/kaist_urban/kalibr_imucam_chain.yaml
@@ -1,0 +1,113 @@
+%YAML:1.0 # need to specify the file type at the top!
+
+# KAIST Complex Urban Dataset (urban28/32/38/39 ...), Point Grey Flea3 stereo + Xsens MTi-300.
+# NOT the same hardware as config/kaist_vio (that one is a RealSense D435 + MAVROS testbed).
+#
+# Extrinsics derived from the dataset's calibration/Vehicle2Stereo.txt and Vehicle2IMU.txt.
+# IMPORTANT: those files describe sensor POSE *IN* the vehicle frame
+# (p_vehicle = R @ p_sensor + T), NOT a vehicle->sensor transform. So:
+#   R_ItoC = R_Vehicle2Stereo.T
+#   p_IinC = R_Vehicle2Stereo.T @ (T_Vehicle2IMU - T_Vehicle2Stereo)
+# Verified by cross-checking against rpng/kaist2bag's independently-calibrated
+# reference values for this exact rig (same camera model/resolution) — the
+# corrected formula matches to ~5 decimal places; the original (un-transposed)
+# version was off by a full rotation inversion and caused immediate EKF
+# divergence (position blew up to 100s of km within seconds of init).
+# Then rotated into the RECTIFIED camera frame (since convert_kaist_to_ros2bag.py
+# undistorts+rectifies images before writing them to the bag).
+# Intrinsics are the post-rectification projection_matrix values from left.yaml/right.yaml
+# (distortion is zero because images are already undistorted by the converter).
+# Values are identical between urban38-pankyo and urban39-pankyo (same calibration
+# session), so this single file covers both sequences.
+
+cam0:
+  T_cam_imu:
+    - - -0.01420717220
+      - -0.99989908800
+      - -0.00057390980
+      - 0.27163774000
+    - - -0.01360966850
+      - 0.00076729004
+      - -0.99990752700
+      - -0.09276405000
+    - - 0.99979698500
+      - -0.01419811180
+      - -0.01361915480
+      - -1.71010806000
+    - - 0.0
+      - 0.0
+      - 0.0
+      - 1.0
+  cam_overlaps:
+    - 1
+  camera_model: pinhole
+  distortion_coeffs:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+  distortion_model: radtan
+  intrinsics:
+    - 781.35803072
+    - 781.35803072
+    - 617.96599579
+    - 263.54596138
+  resolution:
+    - 1280
+    - 560
+  rostopic: /stereo/left/image_rect
+  timeshift_cam_imu: 0.0
+cam1:
+  T_cam_imu:
+    - - -0.01420717220
+      - -0.99989908800
+      - -0.00057390980
+      - -0.20989365000
+    - - -0.01360966850
+      - 0.00076729004
+      - -0.99990752700
+      - -0.09276405000
+    - - 0.99979698500
+      - -0.01419811180
+      - -0.01361915480
+      - -1.71010806000
+    - - 0.0
+      - 0.0
+      - 0.0
+      - 1.0
+  T_cn_cnm1:
+    - - 1.0
+      - 0.0
+      - 0.0
+      - -0.48153139391
+    - - 0.0
+      - 1.0
+      - 0.0
+      - 0.0
+    - - 0.0
+      - 0.0
+      - 1.0
+      - 0.0
+    - - 0.0
+      - 0.0
+      - 0.0
+      - 1.0
+  cam_overlaps:
+    - 0
+  camera_model: pinhole
+  distortion_coeffs:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+  distortion_model: radtan
+  intrinsics:
+    - 781.35803072
+    - 781.35803072
+    - 617.96599579
+    - 263.54596138
+  resolution:
+    - 1280
+    - 560
+  rostopic: /stereo/right/image_rect
+  timeshift_cam_imu: 0.0

--- a/config/kaist_vio/estimator_config.yaml
+++ b/config/kaist_vio/estimator_config.yaml
@@ -128,10 +128,6 @@ use_imu_residual: false
 imu_residual_alpha: 5.0
 imu_residual_sigma_px: 5.0
 
-# Phase 2 JEPA dataset collection
-log_features: false
-log_features_path: ""
-
 
 
 

--- a/config/kaist_vio/estimator_config.yaml
+++ b/config/kaist_vio/estimator_config.yaml
@@ -118,6 +118,20 @@ use_mask: false
 relative_config_imu: "kalibr_imu_chain.yaml"
 relative_config_imucam: "kalibr_imucam_chain.yaml"
 
+# Dynamic mask — not used for KAIST (no segmentation masks available)
+use_dynamic_mask: false
+dynamic_mask_topic0: "/cam0/masked"
+dynamic_mask_topic1: "/cam1/masked"
+
+# Phase 1 IMU-residual noise inflation
+use_imu_residual: false
+imu_residual_alpha: 5.0
+imu_residual_sigma_px: 5.0
+
+# Phase 2 JEPA dataset collection
+log_features: false
+log_features_path: ""
+
 
 
 

--- a/config/tum_vi/estimator_config.yaml
+++ b/config/tum_vi/estimator_config.yaml
@@ -124,9 +124,5 @@ use_imu_residual: false
 imu_residual_alpha: 5.0
 imu_residual_sigma_px: 5.0
 
-# Phase 2 JEPA dataset collection
-log_features: false
-log_features_path: ""
-
 
 

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -87,6 +87,7 @@ knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
 num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
+multi_threading_pubs: false # disable background image-publish thread to prevent cv::Mat race condition on Jetson
 histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -133,4 +133,3 @@ imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = dis
 imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix; 0 = no dead zone
 imu_residual_init_delay: 0.0     # seconds post-init before nm activates; 0 = off (nm runs immediately)
 
-multi_threading_pubs: false  # disable background image-pub thread (crashes on Jetson with sim_time)

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -129,4 +129,5 @@ imu_residual_alpha: 5.0
 imu_residual_sigma_px: 5.0
 use_residual_variance: false
 imu_residual_max_depth: 0.0
+imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = disabled
 

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -127,10 +127,6 @@ dynamic_mask_topic1: "/cam1/masked"
 use_imu_residual: false
 imu_residual_alpha: 5.0
 imu_residual_sigma_px: 5.0
-
-# Phase 2 JEPA dataset collection — disabled by default, zero runtime cost when false.
-# Set log_features: true and supply a run-specific CSV path to collect data.
-# The run number must be embedded in the filename by the calling script.
-log_features: false
-log_features_path: ""
+use_residual_variance: false
+imu_residual_max_depth: 0.0
 

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -1,0 +1,124 @@
+%YAML:1.0 # need to specify the file type at the top!
+
+verbosity: "INFO" # ALL, DEBUG, INFO, WARNING, ERROR, SILENT
+
+use_fej: true # if first-estimate Jacobians should be used (enable for good consistency)
+integration: "rk4" # discrete, rk4, analytical (if rk4 or analytical used then analytical covariance propagation is used)
+use_stereo: true # if we have more than 1 camera, if we should try to track stereo constraints between pairs
+max_cameras: 2 # how many cameras we have 1 = mono, 2 = stereo, >2 = binocular (all mono tracking)
+
+calib_cam_extrinsics: false # if the transform between camera and IMU should be optimized R_ItoC, p_CinI
+calib_cam_intrinsics: false # if camera intrinsics should be optimized (focal, center, distortion)
+calib_cam_timeoffset: false # if timeoffset between camera and IMU should be optimized
+calib_imu_intrinsics: false # if imu intrinsics should be calibrated (rotation and skew-scale matrix)
+calib_imu_g_sensitivity: false # if gyroscope gravity sensitivity (Tg) should be calibrated
+
+max_clones: 11 # how many clones in the sliding window
+max_slam: 50 # number of features in our state vector
+max_slam_in_update: 25 # update can be split into sequential updates of batches, how many in a batch
+max_msckf_in_update: 40 # how many MSCKF features to use in the update
+dt_slam_delay: 1 # delay before initializing (helps with stability from bad initialization...)
+
+gravity_mag: 9.81007 # magnitude of gravity in this location
+
+feat_rep_msckf: "GLOBAL_3D"
+feat_rep_slam: "ANCHORED_MSCKF_INVERSE_DEPTH"
+feat_rep_aruco: "ANCHORED_MSCKF_INVERSE_DEPTH"
+
+# zero velocity update parameters we can use
+# we support either IMU-based or disparity detection.
+try_zupt: true
+zupt_chi2_multipler: 0 # set to 0 for only disp-based
+zupt_max_velocity: 0.1
+zupt_noise_multiplier: 10
+zupt_max_disparity: 0.5 # set to 0 for only imu-based
+zupt_only_at_beginning: false
+
+# ==================================================================
+# ==================================================================
+
+init_window_time: 1.2 # how many seconds to collect initialization information
+init_imu_thresh: 0.5 # threshold for variance of the accelerometer to detect a "jerk" in motion
+init_max_disparity: 20.0 # max disparity to consider the platform stationary (dependent on resolution)
+init_max_features: 75 # how many features to track during initialization (saves on computation)
+
+init_dyn_use: true # if dynamic initialization should be used
+init_dyn_mle_opt_calib: false # if we should optimize calibration during intialization (not recommended)
+init_dyn_mle_max_iter: 50 # how many iterations the MLE refinement should use (zero to skip the MLE)
+init_dyn_mle_max_time: 0.05 # how many seconds the MLE should be completed in
+init_dyn_mle_max_threads: 6 # how many threads the MLE should use
+init_dyn_num_pose: 6 # number of poses to use within our window time (evenly spaced)
+init_dyn_min_deg: 5.0 # orientation change needed to try to init
+
+init_dyn_inflation_ori: 10 # what to inflate the recovered q_GtoI covariance by
+init_dyn_inflation_vel: 100 # what to inflate the recovered v_IinG covariance by
+init_dyn_inflation_bg: 10 # what to inflate the recovered bias_g covariance by
+init_dyn_inflation_ba: 100 # what to inflate the recovered bias_a covariance by
+init_dyn_min_rec_cond: 1e-12 # reciprocal condition number thresh for info inversion
+
+init_dyn_bias_g: [ 0.0, 0.0, 0.0 ] # initial gyroscope bias guess
+init_dyn_bias_a: [ 0.0, 0.0, 0.0 ] # initial accelerometer bias guess
+
+# ==================================================================
+# ==================================================================
+
+record_timing_information: false # if we want to record timing information of the method
+record_timing_filepath: "/tmp/traj_timing.txt" # https://docs.openvins.com/eval-timing.html#eval-ov-timing-flame
+
+# if we want to save the simulation state and its diagional covariance
+# use this with rosrun ov_eval error_simulation
+save_total_state: false
+filepath_est: "/tmp/ov_estimate.txt"
+filepath_std: "/tmp/ov_estimate_std.txt"
+filepath_gt: "/tmp/ov_groundtruth.txt"
+
+# ==================================================================
+# ==================================================================
+
+# our front-end feature tracking parameters
+# we have a KLT and descriptor based (KLT is better implemented...)
+use_klt: true # if true we will use KLT, otherwise use a ORB descriptor + robust matching
+num_pts: 600 # number of points (per camera) we will extract and try to track
+fast_threshold: 10 # threshold for fast extraction (warning: lower threshs can be expensive)
+grid_x: 6 # extraction sub-grid count for horizontal direction (uniform tracking)
+grid_y: 4 # extraction sub-grid count for vertical direction (uniform tracking)
+min_px_dist: 15 # distance between features (features near each other provide less information)
+knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
+track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
+downsample_cameras: false # will downsample image in half if true
+num_opencv_threads: 1 # -1: auto, 0-1: serial, >1: number of threads
+histogram_method: "HISTOGRAM" # NONE, HISTOGRAM, CLAHE
+
+# aruco tag tracker for the system
+# DICT_6X6_1000 from https://chev.me/arucogen/
+use_aruco: false
+num_aruco: 1024
+downsize_aruco: true
+
+# ==================================================================
+# ==================================================================
+
+# camera noises and chi-squared threshold multipliers
+up_msckf_sigma_px: 1.5
+up_msckf_chi2_multipler: 1
+up_slam_sigma_px: 1
+up_slam_chi2_multipler: 1
+up_aruco_sigma_px: 1
+up_aruco_chi2_multipler: 1
+
+# masks for our images
+use_mask: false
+# No need when use mask is false
+mask0: "dummy_mask.png"
+mask1: "dummy_mask.png"
+
+# imu and camera spacial-temporal
+# imu config should also have the correct noise values
+relative_config_imu: "kalibr_imu_chain.yaml"
+relative_config_imucam: "kalibr_imucam_chain.yaml"
+
+# Custom Dynamic Mask
+use_dynamic_mask: true
+dynamic_mask_topic0: "/cam0/masked"
+dynamic_mask_topic1: "/cam1/masked"
+

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -133,3 +133,4 @@ imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = dis
 imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix; 0 = no dead zone
 imu_residual_init_delay: 0.0     # seconds post-init before nm activates; 0 = off (nm runs immediately)
 
+multi_threading_pubs: false  # disable background image-pub thread (crashes on Jetson with sim_time)

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -131,4 +131,5 @@ use_residual_variance: false
 imu_residual_max_depth: 0.0
 imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = disabled
 imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix; 0 = no dead zone
+imu_residual_init_delay: 0.0     # seconds post-init before nm activates; 0 = off (nm runs immediately)
 

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -13,10 +13,10 @@ calib_cam_timeoffset: false # if timeoffset between camera and IMU should be opt
 calib_imu_intrinsics: false # if imu intrinsics should be calibrated (rotation and skew-scale matrix)
 calib_imu_g_sensitivity: false # if gyroscope gravity sensitivity (Tg) should be calibrated
 
-max_clones: 11 # how many clones in the sliding window
+max_clones: 15 # how many clones in the sliding window
 max_slam: 50 # number of features in our state vector
 max_slam_in_update: 25 # update can be split into sequential updates of batches, how many in a batch
-max_msckf_in_update: 40 # how many MSCKF features to use in the update
+max_msckf_in_update: 60 # how many MSCKF features to use in the update
 dt_slam_delay: 1 # delay before initializing (helps with stability from bad initialization...)
 
 gravity_mag: 9.81007 # magnitude of gravity in this location
@@ -40,7 +40,7 @@ zupt_only_at_beginning: false
 init_window_time: 1.2 # how many seconds to collect initialization information
 init_imu_thresh: 0.5 # threshold for variance of the accelerometer to detect a "jerk" in motion
 init_max_disparity: 20.0 # max disparity to consider the platform stationary (dependent on resolution)
-init_max_features: 75 # how many features to track during initialization (saves on computation)
+init_max_features: 150 # how many features to track during initialization (saves on computation)
 
 init_dyn_use: true # if dynamic initialization should be used
 init_dyn_mle_opt_calib: false # if we should optimize calibration during intialization (not recommended)
@@ -79,15 +79,15 @@ filepath_gt: "/tmp/ov_groundtruth.txt"
 # we have a KLT and descriptor based (KLT is better implemented...)
 use_klt: true # if true we will use KLT, otherwise use a ORB descriptor + robust matching
 num_pts: 600 # number of points (per camera) we will extract and try to track
-fast_threshold: 10 # threshold for fast extraction (warning: lower threshs can be expensive)
-grid_x: 6 # extraction sub-grid count for horizontal direction (uniform tracking)
-grid_y: 4 # extraction sub-grid count for vertical direction (uniform tracking)
-min_px_dist: 15 # distance between features (features near each other provide less information)
+fast_threshold: 10 # threshold for fast extraction
+grid_x: 8 # extraction sub-grid count for horizontal direction (uniform tracking)
+grid_y: 6 # extraction sub-grid count for vertical direction (uniform tracking)
+min_px_dist: 10 # distance between features (features near each other provide less information)
 knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
-num_opencv_threads: 1 # -1: auto, 0-1: serial, >1: number of threads
-histogram_method: "HISTOGRAM" # NONE, HISTOGRAM, CLAHE
+num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
+histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system
 # DICT_6X6_1000 from https://chev.me/arucogen/
@@ -121,4 +121,16 @@ relative_config_imucam: "kalibr_imucam_chain.yaml"
 use_dynamic_mask: true
 dynamic_mask_topic0: "/cam0/masked"
 dynamic_mask_topic1: "/cam1/masked"
+
+# Phase 1 Option C: IMU-residual per-feature noise inflation using triangulated depth.
+# Dead-zone = 3 * sigma_pix prevents static-feature inflation.
+use_imu_residual: false
+imu_residual_alpha: 5.0
+imu_residual_sigma_px: 5.0
+
+# Phase 2 JEPA dataset collection — disabled by default, zero runtime cost when false.
+# Set log_features: true and supply a run-specific CSV path to collect data.
+# The run number must be embedded in the filename by the calling script.
+log_features: false
+log_features_path: ""
 

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -87,7 +87,7 @@ knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
 num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
-multi_threading_pubs: false # disable background image-publish thread to prevent cv::Mat race condition on Jetson
+multi_threading_pubs: false # disable background publish thread (prevents startup race on Jetson)
 histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system

--- a/config/viode_config/estimator_config.yaml
+++ b/config/viode_config/estimator_config.yaml
@@ -130,4 +130,5 @@ imu_residual_sigma_px: 5.0
 use_residual_variance: false
 imu_residual_max_depth: 0.0
 imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = disabled
+imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix; 0 = no dead zone
 

--- a/config/viode_config/estimator_config_city.yaml
+++ b/config/viode_config/estimator_config_city.yaml
@@ -87,6 +87,7 @@ knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
 num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
+multi_threading_pubs: false # disable background image-publish thread to prevent cv::Mat race condition on Jetson
 histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system

--- a/config/viode_config/estimator_config_city.yaml
+++ b/config/viode_config/estimator_config_city.yaml
@@ -133,4 +133,3 @@ imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = dis
 imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix; 0 = no dead zone
 imu_residual_init_delay: 0.0     # seconds post-init before nm activates; 0 = off (nm runs immediately)
 
-multi_threading_pubs: false  # disable background image-pub thread (crashes on Jetson with sim_time)

--- a/config/viode_config/estimator_config_city.yaml
+++ b/config/viode_config/estimator_config_city.yaml
@@ -133,3 +133,4 @@ imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = dis
 imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix; 0 = no dead zone
 imu_residual_init_delay: 0.0     # seconds post-init before nm activates; 0 = off (nm runs immediately)
 
+multi_threading_pubs: false  # disable background image-pub thread (crashes on Jetson with sim_time)

--- a/config/viode_config/estimator_config_city.yaml
+++ b/config/viode_config/estimator_config_city.yaml
@@ -78,11 +78,11 @@ filepath_gt: "/tmp/ov_groundtruth.txt"
 # our front-end feature tracking parameters
 # we have a KLT and descriptor based (KLT is better implemented...)
 use_klt: true # if true we will use KLT, otherwise use a ORB descriptor + robust matching
-num_pts: 600 # number of points (per camera) we will extract and try to track
+num_pts: 1000 # city: more features for robustness against fast-motion occlusion (was 600)
 fast_threshold: 10 # threshold for fast extraction
 grid_x: 8 # extraction sub-grid count for horizontal direction (uniform tracking)
 grid_y: 6 # extraction sub-grid count for vertical direction (uniform tracking)
-min_px_dist: 10 # distance between features (features near each other provide less information)
+min_px_dist: 5 # city: denser packing in texture-rich scenes (was 10)
 knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true

--- a/config/viode_config/estimator_config_city.yaml
+++ b/config/viode_config/estimator_config_city.yaml
@@ -87,7 +87,7 @@ knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
 num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
-multi_threading_pubs: false # disable background image-publish thread to prevent cv::Mat race condition on Jetson
+multi_threading_pubs: false # disable background publish thread (prevents startup race on Jetson)
 histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system

--- a/config/viode_config/estimator_config_city_imu_residual.yaml
+++ b/config/viode_config/estimator_config_city_imu_residual.yaml
@@ -87,6 +87,7 @@ knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
 num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
+multi_threading_pubs: false # disable background image-publish thread to prevent cv::Mat race condition on Jetson
 histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system

--- a/config/viode_config/estimator_config_city_imu_residual.yaml
+++ b/config/viode_config/estimator_config_city_imu_residual.yaml
@@ -13,8 +13,8 @@ calib_cam_timeoffset: false # if timeoffset between camera and IMU should be opt
 calib_imu_intrinsics: false # if imu intrinsics should be calibrated (rotation and skew-scale matrix)
 calib_imu_g_sensitivity: false # if gyroscope gravity sensitivity (Tg) should be calibrated
 
-max_clones: 20 # how many clones in the sliding window — was 15; longer window for city-scale motion
-max_slam: 75 # number of features in our state vector — was 50; more stable landmarks
+max_clones: 20 # how many clones in the sliding window — was 15
+max_slam: 75 # number of features in our state vector — was 50
 max_slam_in_update: 25 # update can be split into sequential updates of batches, how many in a batch
 max_msckf_in_update: 100 # how many MSCKF features to use in the update — was 60
 dt_slam_delay: 1 # delay before initializing (helps with stability from bad initialization...)
@@ -78,11 +78,11 @@ filepath_gt: "/tmp/ov_groundtruth.txt"
 # our front-end feature tracking parameters
 # we have a KLT and descriptor based (KLT is better implemented...)
 use_klt: true # if true we will use KLT, otherwise use a ORB descriptor + robust matching
-num_pts: 600 # number of points (per camera) we will extract and try to track
+num_pts: 1000 # city: more features for robustness against fast-motion occlusion (was 600)
 fast_threshold: 10 # threshold for fast extraction
 grid_x: 8 # extraction sub-grid count for horizontal direction (uniform tracking)
 grid_y: 6 # extraction sub-grid count for vertical direction (uniform tracking)
-min_px_dist: 10 # distance between features (features near each other provide less information)
+min_px_dist: 5 # city: denser packing in texture-rich scenes (was 10)
 knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
@@ -100,7 +100,7 @@ downsize_aruco: true
 
 # camera noises and chi-squared threshold multipliers
 up_msckf_sigma_px: 1.5
-up_msckf_chi2_multipler: 2 # was 1 → 3 → 2; 3 over-expanded acceptance zone into YOLO mask boundaries
+up_msckf_chi2_multipler: 2 # was 1 → 3 → 2
 up_slam_sigma_px: 1
 up_slam_chi2_multipler: 2 # was 1 → 3 → 2
 up_aruco_sigma_px: 1
@@ -123,13 +123,14 @@ dynamic_mask_topic0: "/cam0/masked"
 dynamic_mask_topic1: "/cam1/masked"
 
 # Phase 1 Option C: IMU-residual per-feature noise inflation using triangulated depth.
-# Dead-zone = 3 * sigma_pix prevents static-feature inflation.
-use_imu_residual: false
-imu_residual_alpha: 5.0
-imu_residual_sigma_px: 5.0
+# Projection of p_FinG at t_new vs. actual observation: dynamic features get nm >> 1.
+# Dead-zone = 3 * sigma_pix prevents static-feature inflation from GN residual noise.
+use_imu_residual: true
+imu_residual_alpha: 1.5
+imu_residual_sigma_px: 10.0
 use_residual_variance: false
 imu_residual_max_depth: 0.0
 imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = disabled
-imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix; 0 = no dead zone
-imu_residual_init_delay: 0.0     # seconds post-init before nm activates; 0 = off (nm runs immediately)
+imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix = 45px
+imu_residual_init_delay: 5.0     # seconds post-init before nm activates; skips stationary startup
 

--- a/config/viode_config/estimator_config_city_imu_residual.yaml
+++ b/config/viode_config/estimator_config_city_imu_residual.yaml
@@ -134,4 +134,3 @@ imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = dis
 imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix = 45px
 imu_residual_init_delay: 5.0     # seconds post-init before nm activates; skips stationary startup
 
-multi_threading_pubs: false  # disable background image-pub thread (crashes on Jetson with sim_time)

--- a/config/viode_config/estimator_config_city_imu_residual.yaml
+++ b/config/viode_config/estimator_config_city_imu_residual.yaml
@@ -134,3 +134,4 @@ imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = dis
 imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix = 45px
 imu_residual_init_delay: 5.0     # seconds post-init before nm activates; skips stationary startup
 
+multi_threading_pubs: false  # disable background image-pub thread (crashes on Jetson with sim_time)

--- a/config/viode_config/estimator_config_city_imu_residual.yaml
+++ b/config/viode_config/estimator_config_city_imu_residual.yaml
@@ -87,7 +87,7 @@ knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
 num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
-multi_threading_pubs: false # disable background image-publish thread to prevent cv::Mat race condition on Jetson
+multi_threading_pubs: false # disable background publish thread (prevents startup race on Jetson)
 histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system

--- a/config/viode_config/estimator_config_gate.yaml
+++ b/config/viode_config/estimator_config_gate.yaml
@@ -1,0 +1,139 @@
+%YAML:1.0 # need to specify the file type at the top!
+
+# Phase 1 single-frame IMU residual + triangulation quality depth gate.
+# Same as the best Phase 1 config (alpha=3.0, sigma=5.0, single-frame) but adds a
+# depth gate: features beyond max_depth have unreliable p_FinG (low stereo disparity)
+# and are excluded from nm inflation.
+#
+# Motivation: city_night/none and city_night/low fail in Phase 1 because dark scenes
+# force long-range triangulation → poor depth → noisy residuals → false nm inflation.
+# The gate suppresses nm for features > 15m (disparity < 1.3px at VIODE baseline).
+#
+# Gate metric: ATE <= Phase 1 (batch_14, 8/12) on >= 10/12 scenarios.
+#
+# Why variance is bias-invariant:
+#   Triangulation error adds a constant offset c to every r_k (same p_FinG applied
+#   to all clone poses).  var({c+x1,...,c+xN}) = var({x1,...,xN}).  A static feature
+#   has low std_r regardless of triangulation quality; a dynamic feature has high
+#   std_r because its true world position changed while p_FinG stayed fixed.
+#
+# Gate: variance-nm ATE <= Phase 1 single-frame ATE (batch_14, 8/12) on >=10/12 scenarios.
+
+verbosity: "INFO"
+
+use_fej: true
+integration: "rk4"
+use_stereo: true
+max_cameras: 2
+
+calib_cam_extrinsics: false
+calib_cam_intrinsics: false
+calib_cam_timeoffset: false
+calib_imu_intrinsics: false
+calib_imu_g_sensitivity: false
+
+max_clones: 15
+max_slam: 50
+max_slam_in_update: 25
+max_msckf_in_update: 60
+dt_slam_delay: 1
+
+gravity_mag: 9.81007
+
+feat_rep_msckf: "GLOBAL_3D"
+feat_rep_slam: "ANCHORED_MSCKF_INVERSE_DEPTH"
+feat_rep_aruco: "ANCHORED_MSCKF_INVERSE_DEPTH"
+
+try_zupt: true
+zupt_chi2_multipler: 0
+zupt_max_velocity: 0.1
+zupt_noise_multiplier: 10
+zupt_max_disparity: 0.5
+zupt_only_at_beginning: false
+
+# ==================================================================
+
+init_window_time: 1.2
+init_imu_thresh: 0.5
+init_max_disparity: 20.0
+init_max_features: 150
+
+init_dyn_use: true
+init_dyn_mle_opt_calib: false
+init_dyn_mle_max_iter: 50
+init_dyn_mle_max_time: 0.05
+init_dyn_mle_max_threads: 6
+init_dyn_num_pose: 6
+init_dyn_min_deg: 5.0
+
+init_dyn_inflation_ori: 10
+init_dyn_inflation_vel: 100
+init_dyn_inflation_bg: 10
+init_dyn_inflation_ba: 100
+init_dyn_min_rec_cond: 1e-12
+
+init_dyn_bias_g: [ 0.0, 0.0, 0.0 ]
+init_dyn_bias_a: [ 0.0, 0.0, 0.0 ]
+
+# ==================================================================
+
+record_timing_information: false
+record_timing_filepath: "/tmp/traj_timing.txt"
+
+save_total_state: false
+filepath_est: "/tmp/ov_estimate.txt"
+filepath_std: "/tmp/ov_estimate_std.txt"
+filepath_gt: "/tmp/ov_groundtruth.txt"
+
+# ==================================================================
+
+use_klt: true
+num_pts: 600
+fast_threshold: 10
+grid_x: 8
+grid_y: 6
+min_px_dist: 10
+knn_ratio: 0.90
+track_frequency: 21.0
+downsample_cameras: false
+num_opencv_threads: 4
+histogram_method: "CLAHE"
+
+use_aruco: false
+num_aruco: 1024
+downsize_aruco: true
+
+# ==================================================================
+
+up_msckf_sigma_px: 1.5
+up_msckf_chi2_multipler: 1
+up_slam_sigma_px: 1
+up_slam_chi2_multipler: 1
+up_aruco_sigma_px: 1
+up_aruco_chi2_multipler: 1
+
+use_mask: false
+mask0: "dummy_mask.png"
+mask1: "dummy_mask.png"
+
+relative_config_imu: "kalibr_imu_chain.yaml"
+relative_config_imucam: "kalibr_imucam_chain.yaml"
+
+use_dynamic_mask: true
+dynamic_mask_topic0: "/cam0/masked"
+dynamic_mask_topic1: "/cam1/masked"
+
+# ==================================================================
+# Phase 1 single-frame + depth gate
+# ==================================================================
+
+use_imu_residual: true
+imu_residual_alpha: 3.0
+imu_residual_sigma_px: 5.0
+
+# Single-frame mode (best; variance mode is disabled)
+use_residual_variance: false
+
+# Depth gate: suppress nm for features beyond 15m.
+# Stereo disparity at 15m: 0.05m * 376px / 15m = 1.25px (unreliable).
+imu_residual_max_depth: 15.0

--- a/config/viode_config/estimator_config_imu_residual.yaml
+++ b/config/viode_config/estimator_config_imu_residual.yaml
@@ -87,6 +87,7 @@ knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
 num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
+multi_threading_pubs: false # disable background image-publish thread to prevent cv::Mat race condition on Jetson
 histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system

--- a/config/viode_config/estimator_config_imu_residual.yaml
+++ b/config/viode_config/estimator_config_imu_residual.yaml
@@ -7,19 +7,19 @@ integration: "rk4" # discrete, rk4, analytical (if rk4 or analytical used then a
 use_stereo: true # if we have more than 1 camera, if we should try to track stereo constraints between pairs
 max_cameras: 2 # how many cameras we have 1 = mono, 2 = stereo, >2 = binocular (all mono tracking)
 
-calib_cam_extrinsics: true # if the transform between camera and IMU should be optimized R_ItoC, p_CinI
-calib_cam_intrinsics: true # if camera intrinsics should be optimized (focal, center, distortion)
-calib_cam_timeoffset: true # if timeoffset between camera and IMU should be optimized
+calib_cam_extrinsics: false # if the transform between camera and IMU should be optimized R_ItoC, p_CinI
+calib_cam_intrinsics: false # if camera intrinsics should be optimized (focal, center, distortion)
+calib_cam_timeoffset: false # if timeoffset between camera and IMU should be optimized
 calib_imu_intrinsics: false # if imu intrinsics should be calibrated (rotation and skew-scale matrix)
 calib_imu_g_sensitivity: false # if gyroscope gravity sensitivity (Tg) should be calibrated
 
-max_clones: 11 # how many clones in the sliding window
+max_clones: 15 # how many clones in the sliding window
 max_slam: 50 # number of features in our state vector
 max_slam_in_update: 25 # update can be split into sequential updates of batches, how many in a batch
-max_msckf_in_update: 40 # how many MSCKF features to use in the update
+max_msckf_in_update: 60 # how many MSCKF features to use in the update
 dt_slam_delay: 1 # delay before initializing (helps with stability from bad initialization...)
 
-gravity_mag: 9.81 # magnitude of gravity in this location
+gravity_mag: 9.81007 # magnitude of gravity in this location
 
 feat_rep_msckf: "GLOBAL_3D"
 feat_rep_slam: "ANCHORED_MSCKF_INVERSE_DEPTH"
@@ -27,7 +27,7 @@ feat_rep_aruco: "ANCHORED_MSCKF_INVERSE_DEPTH"
 
 # zero velocity update parameters we can use
 # we support either IMU-based or disparity detection.
-try_zupt: false
+try_zupt: true
 zupt_chi2_multipler: 0 # set to 0 for only disp-based
 zupt_max_velocity: 0.1
 zupt_noise_multiplier: 10
@@ -37,18 +37,18 @@ zupt_only_at_beginning: false
 # ==================================================================
 # ==================================================================
 
-init_window_time: 2.0 # how many seconds to collect initialization information
-init_imu_thresh: 1.5 # threshold for variance of the accelerometer to detect a "jerk" in motion
-init_max_disparity: 10.0 # max disparity to consider the platform stationary (dependent on resolution)
-init_max_features: 50 # how many features to track during initialization (saves on computation)
+init_window_time: 1.2 # how many seconds to collect initialization information
+init_imu_thresh: 0.5 # threshold for variance of the accelerometer to detect a "jerk" in motion
+init_max_disparity: 20.0 # max disparity to consider the platform stationary (dependent on resolution)
+init_max_features: 150 # how many features to track during initialization (saves on computation)
 
-init_dyn_use: false # if dynamic initialization should be used
+init_dyn_use: true # if dynamic initialization should be used
 init_dyn_mle_opt_calib: false # if we should optimize calibration during intialization (not recommended)
 init_dyn_mle_max_iter: 50 # how many iterations the MLE refinement should use (zero to skip the MLE)
 init_dyn_mle_max_time: 0.05 # how many seconds the MLE should be completed in
 init_dyn_mle_max_threads: 6 # how many threads the MLE should use
 init_dyn_num_pose: 6 # number of poses to use within our window time (evenly spaced)
-init_dyn_min_deg: 10.0 # orientation change needed to try to init
+init_dyn_min_deg: 5.0 # orientation change needed to try to init
 
 init_dyn_inflation_ori: 10 # what to inflate the recovered q_GtoI covariance by
 init_dyn_inflation_vel: 100 # what to inflate the recovered v_IinG covariance by
@@ -78,16 +78,16 @@ filepath_gt: "/tmp/ov_groundtruth.txt"
 # our front-end feature tracking parameters
 # we have a KLT and descriptor based (KLT is better implemented...)
 use_klt: true # if true we will use KLT, otherwise use a ORB descriptor + robust matching
-num_pts: 200 # number of points (per camera) we will extract and try to track
-fast_threshold: 20 # threshold for fast extraction (warning: lower threshs can be expensive)
-grid_x: 5 # extraction sub-grid count for horizontal direction (uniform tracking)
-grid_y: 5 # extraction sub-grid count for vertical direction (uniform tracking)
+num_pts: 600 # number of points (per camera) we will extract and try to track
+fast_threshold: 10 # threshold for fast extraction
+grid_x: 8 # extraction sub-grid count for horizontal direction (uniform tracking)
+grid_y: 6 # extraction sub-grid count for vertical direction (uniform tracking)
 min_px_dist: 10 # distance between features (features near each other provide less information)
-knn_ratio: 0.70 # descriptor knn threshold for the top two descriptor matches
+knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
 num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
-histogram_method: "HISTOGRAM" # NONE, HISTOGRAM, CLAHE
+histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system
 # DICT_6X6_1000 from https://chev.me/arucogen/
@@ -99,7 +99,7 @@ downsize_aruco: true
 # ==================================================================
 
 # camera noises and chi-squared threshold multipliers
-up_msckf_sigma_px: 1
+up_msckf_sigma_px: 1.5
 up_msckf_chi2_multipler: 1
 up_slam_sigma_px: 1
 up_slam_chi2_multipler: 1
@@ -108,26 +108,24 @@ up_aruco_chi2_multipler: 1
 
 # masks for our images
 use_mask: false
+# No need when use mask is false
+mask0: "dummy_mask.png"
+mask1: "dummy_mask.png"
 
 # imu and camera spacial-temporal
 # imu config should also have the correct noise values
 relative_config_imu: "kalibr_imu_chain.yaml"
 relative_config_imucam: "kalibr_imucam_chain.yaml"
 
-# Dynamic mask — not used for EuRoC (no segmentation masks available)
-use_dynamic_mask: false
+# Custom Dynamic Mask
+use_dynamic_mask: true
 dynamic_mask_topic0: "/cam0/masked"
 dynamic_mask_topic1: "/cam1/masked"
 
-# Phase 1 IMU-residual noise inflation — disabled by default
-use_imu_residual: false
-imu_residual_alpha: 5.0
+# Phase 1 Option C: IMU-residual per-feature noise inflation using triangulated depth.
+# Projection of p_FinG at t_new vs. actual observation: dynamic features get nm >> 1.
+# Dead-zone = 3 * sigma_pix prevents static-feature inflation from GN residual noise.
+use_imu_residual: true
+imu_residual_alpha: 3.0
 imu_residual_sigma_px: 5.0
-
-# Phase 2 JEPA dataset collection — disabled by default, zero runtime cost when false.
-log_features: false
-log_features_path: ""
-
-
-
 

--- a/config/viode_config/estimator_config_imu_residual.yaml
+++ b/config/viode_config/estimator_config_imu_residual.yaml
@@ -126,8 +126,11 @@ dynamic_mask_topic1: "/cam1/masked"
 # Projection of p_FinG at t_new vs. actual observation: dynamic features get nm >> 1.
 # Dead-zone = 3 * sigma_pix prevents static-feature inflation from GN residual noise.
 use_imu_residual: true
-imu_residual_alpha: 3.0
-imu_residual_sigma_px: 5.0
+imu_residual_alpha: 1.5
+imu_residual_sigma_px: 10.0
 use_residual_variance: false
 imu_residual_max_depth: 0.0
+imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = disabled
+imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix = 45px
+imu_residual_init_delay: 5.0     # seconds post-init before nm activates; skips stationary startup
 

--- a/config/viode_config/estimator_config_imu_residual.yaml
+++ b/config/viode_config/estimator_config_imu_residual.yaml
@@ -134,4 +134,3 @@ imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = dis
 imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix = 45px
 imu_residual_init_delay: 5.0     # seconds post-init before nm activates; skips stationary startup
 
-multi_threading_pubs: false  # disable background image-pub thread (crashes on Jetson with sim_time)

--- a/config/viode_config/estimator_config_imu_residual.yaml
+++ b/config/viode_config/estimator_config_imu_residual.yaml
@@ -134,3 +134,4 @@ imu_residual_max_tri_error: 0.0   # triangulation quality gate (px RMS); 0 = dis
 imu_residual_dead_zone: 3.0       # dead-zone multiplier: noise_floor = dead_zone * sigma_pix = 45px
 imu_residual_init_delay: 5.0     # seconds post-init before nm activates; skips stationary startup
 
+multi_threading_pubs: false  # disable background image-pub thread (crashes on Jetson with sim_time)

--- a/config/viode_config/estimator_config_imu_residual.yaml
+++ b/config/viode_config/estimator_config_imu_residual.yaml
@@ -128,4 +128,6 @@ dynamic_mask_topic1: "/cam1/masked"
 use_imu_residual: true
 imu_residual_alpha: 3.0
 imu_residual_sigma_px: 5.0
+use_residual_variance: false
+imu_residual_max_depth: 0.0
 

--- a/config/viode_config/estimator_config_imu_residual.yaml
+++ b/config/viode_config/estimator_config_imu_residual.yaml
@@ -87,7 +87,7 @@ knn_ratio: 0.90 # descriptor knn threshold for the top two descriptor matches
 track_frequency: 21.0 # frequency we will perform feature tracking at (in frames per second / hertz)
 downsample_cameras: false # will downsample image in half if true
 num_opencv_threads: 4 # -1: auto, 0-1: serial, >1: number of threads
-multi_threading_pubs: false # disable background image-publish thread to prevent cv::Mat race condition on Jetson
+multi_threading_pubs: false # disable background publish thread (prevents startup race on Jetson)
 histogram_method: "CLAHE" # NONE, HISTOGRAM, CLAHE
 
 # aruco tag tracker for the system

--- a/config/viode_config/estimator_config_imu_residual.yaml
+++ b/config/viode_config/estimator_config_imu_residual.yaml
@@ -13,10 +13,10 @@ calib_cam_timeoffset: false # if timeoffset between camera and IMU should be opt
 calib_imu_intrinsics: false # if imu intrinsics should be calibrated (rotation and skew-scale matrix)
 calib_imu_g_sensitivity: false # if gyroscope gravity sensitivity (Tg) should be calibrated
 
-max_clones: 15 # how many clones in the sliding window
-max_slam: 50 # number of features in our state vector
+max_clones: 20 # how many clones in the sliding window — was 15
+max_slam: 75 # number of features in our state vector — was 50
 max_slam_in_update: 25 # update can be split into sequential updates of batches, how many in a batch
-max_msckf_in_update: 60 # how many MSCKF features to use in the update
+max_msckf_in_update: 100 # how many MSCKF features to use in the update — was 60
 dt_slam_delay: 1 # delay before initializing (helps with stability from bad initialization...)
 
 gravity_mag: 9.81007 # magnitude of gravity in this location
@@ -100,9 +100,9 @@ downsize_aruco: true
 
 # camera noises and chi-squared threshold multipliers
 up_msckf_sigma_px: 1.5
-up_msckf_chi2_multipler: 1
+up_msckf_chi2_multipler: 2 # was 1 → 3 → 2
 up_slam_sigma_px: 1
-up_slam_chi2_multipler: 1
+up_slam_chi2_multipler: 2 # was 1 → 3 → 2
 up_aruco_sigma_px: 1
 up_aruco_chi2_multipler: 1
 

--- a/config/viode_config/estimator_config_var.yaml
+++ b/config/viode_config/estimator_config_var.yaml
@@ -1,0 +1,131 @@
+%YAML:1.0 # need to specify the file type at the top!
+
+# Residual-variance IMU noise inflation.
+# Instead of using the reprojection residual at the newest clone only, we compute
+# the std-dev of residuals across ALL sliding-window clones.
+#
+# Why variance is bias-invariant:
+#   Triangulation error adds a constant offset c to every r_k (same p_FinG applied
+#   to all clone poses).  var({c+x1,...,c+xN}) = var({x1,...,xN}).  A static feature
+#   has low std_r regardless of triangulation quality; a dynamic feature has high
+#   std_r because its true world position changed while p_FinG stayed fixed.
+#
+# Gate: variance-nm ATE <= Phase 1 single-frame ATE (batch_14, 8/12) on >=10/12 scenarios.
+
+verbosity: "INFO"
+
+use_fej: true
+integration: "rk4"
+use_stereo: true
+max_cameras: 2
+
+calib_cam_extrinsics: false
+calib_cam_intrinsics: false
+calib_cam_timeoffset: false
+calib_imu_intrinsics: false
+calib_imu_g_sensitivity: false
+
+max_clones: 15
+max_slam: 50
+max_slam_in_update: 25
+max_msckf_in_update: 60
+dt_slam_delay: 1
+
+gravity_mag: 9.81007
+
+feat_rep_msckf: "GLOBAL_3D"
+feat_rep_slam: "ANCHORED_MSCKF_INVERSE_DEPTH"
+feat_rep_aruco: "ANCHORED_MSCKF_INVERSE_DEPTH"
+
+try_zupt: true
+zupt_chi2_multipler: 0
+zupt_max_velocity: 0.1
+zupt_noise_multiplier: 10
+zupt_max_disparity: 0.5
+zupt_only_at_beginning: false
+
+# ==================================================================
+
+init_window_time: 1.2
+init_imu_thresh: 0.5
+init_max_disparity: 20.0
+init_max_features: 150
+
+init_dyn_use: true
+init_dyn_mle_opt_calib: false
+init_dyn_mle_max_iter: 50
+init_dyn_mle_max_time: 0.05
+init_dyn_mle_max_threads: 6
+init_dyn_num_pose: 6
+init_dyn_min_deg: 5.0
+
+init_dyn_inflation_ori: 10
+init_dyn_inflation_vel: 100
+init_dyn_inflation_bg: 10
+init_dyn_inflation_ba: 100
+init_dyn_min_rec_cond: 1e-12
+
+init_dyn_bias_g: [ 0.0, 0.0, 0.0 ]
+init_dyn_bias_a: [ 0.0, 0.0, 0.0 ]
+
+# ==================================================================
+
+record_timing_information: false
+record_timing_filepath: "/tmp/traj_timing.txt"
+
+save_total_state: false
+filepath_est: "/tmp/ov_estimate.txt"
+filepath_std: "/tmp/ov_estimate_std.txt"
+filepath_gt: "/tmp/ov_groundtruth.txt"
+
+# ==================================================================
+
+use_klt: true
+num_pts: 600
+fast_threshold: 10
+grid_x: 8
+grid_y: 6
+min_px_dist: 10
+knn_ratio: 0.90
+track_frequency: 21.0
+downsample_cameras: false
+num_opencv_threads: 4
+histogram_method: "CLAHE"
+
+use_aruco: false
+num_aruco: 1024
+downsize_aruco: true
+
+# ==================================================================
+
+up_msckf_sigma_px: 1.5
+up_msckf_chi2_multipler: 1
+up_slam_sigma_px: 1
+up_slam_chi2_multipler: 1
+up_aruco_sigma_px: 1
+up_aruco_chi2_multipler: 1
+
+use_mask: false
+mask0: "dummy_mask.png"
+mask1: "dummy_mask.png"
+
+relative_config_imu: "kalibr_imu_chain.yaml"
+relative_config_imucam: "kalibr_imucam_chain.yaml"
+
+use_dynamic_mask: true
+dynamic_mask_topic0: "/cam0/masked"
+dynamic_mask_topic1: "/cam1/masked"
+
+# ==================================================================
+# Residual-variance noise inflation
+# ==================================================================
+
+use_imu_residual: true
+# alpha=3.0: best value from Phase 1 single-frame ablation (batch_14, 8/12 wins).
+imu_residual_alpha: 3.0
+# sigma_px: decay constant — same scale as single-frame mode; std_r ≈ sigma_px → nm ≈ 1+alpha*(1-1/e)
+imu_residual_sigma_px: 5.0
+
+# Enable variance mode (cross-clone std-dev instead of single-frame residual).
+use_residual_variance: true
+imu_residual_max_depth: 0.0

--- a/config/viode_config/kalibr_imu_chain.yaml
+++ b/config/viode_config/kalibr_imu_chain.yaml
@@ -6,10 +6,10 @@ imu0:
     - [0.0, 1.0, 0.0, 0.0]
     - [0.0, 0.0, 1.0, 0.0]
     - [0.0, 0.0, 0.0, 1.0]
-  accelerometer_noise_density: 0.2  # [ m / s^2 / sqrt(Hz) ]   ( accel "white noise" )
-  accelerometer_random_walk: 0.02    # [ m / s^3 / sqrt(Hz) ].  ( accel bias diffusion )
-  gyroscope_noise_density: 0.05     # [ rad / s / sqrt(Hz) ]   ( gyro "white noise" )
-  gyroscope_random_walk: 4.0e-5       # [ rad / s^2 / sqrt(Hz) ] ( gyro bias diffusion )
+  accelerometer_noise_density: 0.04  # [ m / s^2 / sqrt(Hz) ]   ( accel "white noise" ) — AirSim synthetic; was 0.2 (real IMU, 5x too high)
+  accelerometer_random_walk: 0.004   # [ m / s^3 / sqrt(Hz) ].  ( accel bias diffusion ) — was 0.02
+  gyroscope_noise_density: 0.004     # [ rad / s / sqrt(Hz) ]   ( gyro "white noise" ) — AirSim synthetic; was 0.05 (12x too high)
+  gyroscope_random_walk: 4.0e-6      # [ rad / s^2 / sqrt(Hz) ] ( gyro bias diffusion ) — was 4e-5
   rostopic: /imu0
   time_offset: 0.0
   update_rate: 200.0

--- a/config/viode_config/kalibr_imu_chain.yaml
+++ b/config/viode_config/kalibr_imu_chain.yaml
@@ -1,0 +1,44 @@
+%YAML:1.0
+
+imu0:
+  T_i_b:
+    - [1.0, 0.0, 0.0, 0.0]
+    - [0.0, 1.0, 0.0, 0.0]
+    - [0.0, 0.0, 1.0, 0.0]
+    - [0.0, 0.0, 0.0, 1.0]
+  accelerometer_noise_density: 0.2  # [ m / s^2 / sqrt(Hz) ]   ( accel "white noise" )
+  accelerometer_random_walk: 0.02    # [ m / s^3 / sqrt(Hz) ].  ( accel bias diffusion )
+  gyroscope_noise_density: 0.05     # [ rad / s / sqrt(Hz) ]   ( gyro "white noise" )
+  gyroscope_random_walk: 4.0e-5       # [ rad / s^2 / sqrt(Hz) ] ( gyro bias diffusion )
+  rostopic: /imu0
+  time_offset: 0.0
+  update_rate: 200.0
+  # three different modes supported:
+  # "calibrated" (same as "kalibr"), "kalibr", "rpng"
+  model: "kalibr"
+  # how to get from Kalibr imu.yaml result file:
+  #   - Tw is imu0:gyroscopes:M:
+  #   - R_IMUtoGYRO: is imu0:gyroscopes:C_gyro_i:
+  #   - Ta is imu0:accelerometers:M:
+  #   - R_IMUtoACC not used by Kalibr
+  #   - Tg is imu0:gyroscopes:A:
+  Tw:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  R_IMUtoGYRO:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  Ta:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  R_IMUtoACC:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  Tg:
+    - [ 0.0, 0.0, 0.0 ]
+    - [ 0.0, 0.0, 0.0 ]
+    - [ 0.0, 0.0, 0.0 ]

--- a/config/viode_config/kalibr_imucam_chain.yaml
+++ b/config/viode_config/kalibr_imucam_chain.yaml
@@ -1,0 +1,28 @@
+%YAML:1.0
+
+cam0:
+  T_imu_cam: #rotation from camera to IMU R_CtoI, position of camera in IMU p_CinI
+    - [0.0, 0.0, 1.0, 0.0]
+    - [1.0, 0.0, 0.0, 0.0]
+    - [0.0, 1.0, 0.0, 0.0]
+    - [0.0, 0.0, 0.0, 1.0]
+  cam_overlaps: [1]
+  camera_model: pinhole
+  distortion_coeffs: [0.0, 0.0, 0.0, 0.0]
+  distortion_model: radtan
+  intrinsics: [376.0, 376.0, 376.0, 240.0] #fu, fv, cu, cv
+  resolution: [752, 480]
+  rostopic: /cam0/image_raw
+cam1:
+  T_imu_cam: #rotation from camera to IMU R_CtoI, position of camera in IMU p_CinI
+    - [0.0, 0.0, 1.0, 0.0]
+    - [1.0, 0.0, 0.0, 0.05]
+    - [0.0, 1.0, 0.0, 0.0]
+    - [0.0, 0.0, 0.0, 1.0]
+  cam_overlaps: [0]
+  camera_model: pinhole
+  distortion_coeffs: [0.0, 0.0, 0.0, 0.0]
+  distortion_model: radtan
+  intrinsics: [376.0, 376.0, 376.0, 240.0] #fu, fv, cu, cv
+  resolution: [752, 480]
+  rostopic: /cam1/image_raw

--- a/config/zedx_config/estimator_config_zedx.yaml
+++ b/config/zedx_config/estimator_config_zedx.yaml
@@ -1,10 +1,16 @@
 %YAML:1.0 # need to specify the file type at the top!
 
-# KAIST Complex Urban Dataset (urban38/urban39).
-# Point Grey Flea3 stereo (1280x560 @ ~10Hz, baseline ~0.48m) + Xsens MTi-300 IMU (100Hz).
-# Bags produced by convert_kaist_to_ros2bag.py — raw images (no pre-rectification).
-# Parameter values copied from config/kaist/ (official OpenVINS KAIST config),
-# adapted for our dynamic-mask evaluation setup.
+# SoftGate-VIO — ZED X stereo camera (live deployment config)
+#
+# Based on KAIST Complex Urban config (real-hardware, non-simulation defaults).
+# Camera: Stereolabs ZED X stereo (1280×720 @ 30 Hz, rectified images)
+# IMU: Xsens MTi-300 (100 Hz) or ZED X internal IMU (400 Hz)
+#
+# TODO before first run:
+#   1. Fill kalibr_imucam_chain_zedx.yaml (intrinsics, extrinsics, rostopics)
+#   2. Fill kalibr_imu_chain_zedx.yaml (noise params, rostopic, update_rate)
+#   3. Verify track_frequency matches your ZED wrapper framerate setting
+#   4. If using online time-offset calibration, set calib_cam_timeoffset: true
 
 verbosity: "INFO"
 
@@ -14,8 +20,8 @@ use_stereo: true
 max_cameras: 2
 
 calib_cam_extrinsics: false
-calib_cam_intrinsics: true
-calib_cam_timeoffset: true
+calib_cam_intrinsics: false      # trust ZED SDK / Kalibr calibration for first runs
+calib_cam_timeoffset: false      # enable once calibration is good; helps long sequences
 calib_imu_intrinsics: false
 calib_imu_g_sensitivity: false
 
@@ -28,10 +34,10 @@ dt_slam_delay: 1
 gravity_mag: 9.81
 
 feat_rep_msckf: "ANCHORED_MSCKF_INVERSE_DEPTH"
-feat_rep_slam: "ANCHORED_MSCKF_INVERSE_DEPTH"
+feat_rep_slam:  "ANCHORED_MSCKF_INVERSE_DEPTH"
 feat_rep_aruco: "ANCHORED_MSCKF_INVERSE_DEPTH"
 
-# ZUPT: urban driving has stop lights — zero-velocity updates during stops reduce bias drift
+# ZUPT: useful for vehicles that stop at traffic lights / intersections
 try_zupt: true
 zupt_chi2_multipler: 0.5
 zupt_max_velocity: 0.1
@@ -40,14 +46,13 @@ zupt_max_disparity: 0.4
 zupt_only_at_beginning: false
 
 # ==================================================================
-# ==================================================================
 
 init_window_time: 2.0
 init_imu_thresh: 0.5
 init_max_disparity: 1.5
 init_max_features: 50
 
-init_dyn_use: false
+init_dyn_use: false               # static initializer — deterministic, no MLE divergence
 init_dyn_mle_opt_calib: false
 init_dyn_mle_max_iter: 50
 init_dyn_mle_max_time: 0.05
@@ -65,7 +70,6 @@ init_dyn_bias_g: [0.0, 0.0, 0.0]
 init_dyn_bias_a: [0.0, 0.0, 0.0]
 
 # ==================================================================
-# ==================================================================
 
 record_timing_information: false
 record_timing_filepath: "/tmp/traj_timing.txt"
@@ -73,25 +77,24 @@ record_timing_filepath: "/tmp/traj_timing.txt"
 save_total_state: false
 filepath_est: "/tmp/ov_estimate.txt"
 filepath_std: "/tmp/ov_estimate_std.txt"
-filepath_gt: "/tmp/ov_groundtruth.txt"
+filepath_gt:  "/tmp/ov_groundtruth.txt"
 
-# ==================================================================
 # ==================================================================
 
 use_klt: true
-num_pts: 200
+num_pts: 200                  # Jetson-safe budget; raise to 300 on Orin if CPU budget allows
 fast_threshold: 30
 grid_x: 5
 grid_y: 5
 min_px_dist: 20
 knn_ratio: 0.65
-track_frequency: 31.0
+track_frequency: 30.0         # TODO: match your ZED wrapper framerate (15/30/60 Hz)
 downsample_cameras: false
 num_opencv_threads: 4
 histogram_method: "HISTOGRAM"
 
 fi_min_dist: 0.25
-fi_max_dist: 150.0        # urban features at 20-150m; was 10.0 (rejected almost everything)
+fi_max_dist: 100.0            # urban features typically < 100 m
 fi_max_baseline: 200
 fi_max_cond_number: 20000
 fi_triangulate_1d: false
@@ -100,7 +103,6 @@ use_aruco: false
 num_aruco: 1024
 downsize_aruco: true
 
-# ==================================================================
 # ==================================================================
 
 up_msckf_sigma_px: 1.5
@@ -112,16 +114,18 @@ up_aruco_chi2_multipler: 1
 
 use_mask: false
 
-relative_config_imu: "kalibr_imu_chain.yaml"
-relative_config_imucam: "kalibr_imucam_chain.yaml"
+relative_config_imu:    "kalibr_imu_chain_zedx.yaml"
+relative_config_imucam: "kalibr_imucam_chain_zedx.yaml"
 
-# Dynamic mask: always true — yolo_masker runs with force_empty for unmasked/imu_only.
-# Input topics are remapped to KAIST stereo topics at launch time.
+# Dynamic mask: yolo_masker publishes /cam0/masked and /cam1/masked.
+# Set to false and set force_empty:=true in the masker to run without masking.
 use_dynamic_mask: true
 dynamic_mask_topic0: "/cam0/masked"
 dynamic_mask_topic1: "/cam1/masked"
 
-use_imu_residual: false
+# SoftGate nm — IMU reprojection residual gate.
+# Set use_imu_residual: false for a clean baseline without SoftGate.
+use_imu_residual: true
 imu_residual_alpha: 1.5
 imu_residual_sigma_px: 10.0
 use_residual_variance: false

--- a/config/zedx_config/kalibr_imu_chain_zedx.yaml
+++ b/config/zedx_config/kalibr_imu_chain_zedx.yaml
@@ -1,0 +1,52 @@
+%YAML:1.0 # need to specify the file type at the top!
+
+# IMU calibration for ZED X + Xsens (or ZED X internal IMU)
+#
+# TODO — set rostopic to match your IMU driver:
+#   Xsens MTi (bluespace_ai / xsens_mti_ros2_driver): /imu/data
+#   ZED X internal IMU (ZED ROS2 wrapper v4):          /zed/zed_node/imu/data
+#
+# TODO — fill noise parameters from your IMU's datasheet or Kalibr IMU calibration.
+#   Xsens MTi-300 (KAIST config reference values shown below).
+#   ZED X internal IMU is noisier — use Kalibr imu_utils to measure actual values.
+#
+# update_rate: set to actual IMU publish rate (Xsens MTi-300: 100 Hz, ZED X internal: 400 Hz).
+
+imu0:
+  T_i_b:
+    - [1.0, 0.0, 0.0, 0.0]
+    - [0.0, 1.0, 0.0, 0.0]
+    - [0.0, 0.0, 1.0, 0.0]
+    - [0.0, 0.0, 0.0, 1.0]
+
+  # TODO: replace with values from your IMU datasheet or Kalibr imu_utils calibration
+  accelerometer_noise_density: 5.8860e-03   # [ m / s^2 / sqrt(Hz) ]  (Xsens MTi-300 reference)
+  accelerometer_random_walk:   1.0000e-04   # [ m / s^3 / sqrt(Hz) ]
+  gyroscope_noise_density:     1.7453e-04   # [ rad / s / sqrt(Hz) ]  (Xsens MTi-300 reference)
+  gyroscope_random_walk:       1.0000e-05   # [ rad / s^2 / sqrt(Hz) ]
+
+  rostopic: /imu/data   # TODO: change to /zed/zed_node/imu/data if using ZED X internal IMU
+  time_offset: 0.0
+  update_rate: 100.0    # TODO: set to actual IMU rate (Xsens MTi-300: 100, ZED X: 400)
+  model: "kalibr"
+
+  Tw:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  R_IMUtoGYRO:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  Ta:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  R_IMUtoACC:
+    - [ 1.0, 0.0, 0.0 ]
+    - [ 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0 ]
+  Tg:
+    - [ 0.0, 0.0, 0.0 ]
+    - [ 0.0, 0.0, 0.0 ]
+    - [ 0.0, 0.0, 0.0 ]

--- a/config/zedx_config/kalibr_imucam_chain_zedx.yaml
+++ b/config/zedx_config/kalibr_imucam_chain_zedx.yaml
@@ -1,0 +1,49 @@
+%YAML:1.0 # need to specify the file type at the top!
+
+# Stereo camera calibration for ZED X
+#
+# TODO — fill cam0 and cam1 from your Kalibr calibration output or the ZED SDK.
+#
+# Getting intrinsics from ZED SDK (no Kalibr needed):
+#   sl::Camera zed;
+#   auto cal = zed.getCameraInformation().camera_configuration.calibration_parameters;
+#   // cal.left_cam  → fx, fy, cx, cy, k1, k2, p1, p2
+#   // cal.right_cam → same
+#   // cal.T → translation vector cam0→cam1
+#
+# For rectified images (image_rect_gray), set distortion_coeffs to [0,0,0,0]
+# and use the rectified focal length (fx_rect = fy_rect) from ZED SDK.
+#
+# rostopic: must match the ZED ROS2 wrapper topic names for your configuration.
+# ZED ROS2 wrapper v4 defaults (namespace "zed", node_name "zed_node"):
+#   /zed/zed_node/left/image_rect_gray
+#   /zed/zed_node/right/image_rect_gray
+# If you changed camera_name/node_name in zed_camera.yaml, update accordingly.
+
+cam0:
+  T_imu_cam:   # R_CtoI | p_CinI  (rotation from cam0 to IMU, position of cam0 in IMU frame)
+    - [ 1.0, 0.0, 0.0, 0.0 ]   # TODO: fill from Kalibr or ZED SDK extrinsics
+    - [ 0.0, 1.0, 0.0, 0.0 ]
+    - [ 0.0, 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 0.0, 1.0 ]
+  cam_overlaps: [1]
+  camera_model: pinhole
+  distortion_coeffs: [0.0, 0.0, 0.0, 0.0]   # TODO: fill (use [0,0,0,0] for rectified images)
+  distortion_model: radtan
+  intrinsics: [700.0, 700.0, 640.0, 360.0]   # TODO: [fx, fy, cx, cy] in pixels
+  resolution: [1280, 720]                     # TODO: match ZED wrapper resolution setting
+  rostopic: /zed/zed_node/left/image_rect_gray  # TODO: verify — see note above
+
+cam1:
+  T_imu_cam:   # R_CtoI | p_CinI  (rotation from cam1 to IMU, position of cam1 in IMU frame)
+    - [ 1.0, 0.0, 0.0, 0.0 ]   # TODO: fill from Kalibr or ZED SDK extrinsics
+    - [ 0.0, 1.0, 0.0,-0.12 ]  # TODO: -0.12 is a placeholder for ~120mm baseline (replace)
+    - [ 0.0, 0.0, 1.0, 0.0 ]
+    - [ 0.0, 0.0, 0.0, 1.0 ]
+  cam_overlaps: [0]
+  camera_model: pinhole
+  distortion_coeffs: [0.0, 0.0, 0.0, 0.0]   # TODO: fill
+  distortion_model: radtan
+  intrinsics: [700.0, 700.0, 640.0, 360.0]   # TODO: [fx, fy, cx, cy] in pixels
+  resolution: [1280, 720]                     # TODO: match ZED wrapper resolution setting
+  rostopic: /zed/zed_node/right/image_rect_gray  # TODO: verify — see note above

--- a/ov_core/src/plot/matplotlibcpp.h
+++ b/ov_core/src/plot/matplotlibcpp.h
@@ -257,18 +257,42 @@ inline bool annotate(std::string annotation, double x, double y) {
 
 #ifndef WITHOUT_NUMPY
 // Type selector for numpy array conversion
-template <typename T> struct select_npy_type { const static NPY_TYPES type = NPY_NOTYPE; }; // Default
-template <> struct select_npy_type<double> { const static NPY_TYPES type = NPY_DOUBLE; };
-template <> struct select_npy_type<float> { const static NPY_TYPES type = NPY_FLOAT; };
-template <> struct select_npy_type<bool> { const static NPY_TYPES type = NPY_BOOL; };
-template <> struct select_npy_type<int8_t> { const static NPY_TYPES type = NPY_INT8; };
-template <> struct select_npy_type<int16_t> { const static NPY_TYPES type = NPY_SHORT; };
-template <> struct select_npy_type<int32_t> { const static NPY_TYPES type = NPY_INT; };
-template <> struct select_npy_type<int64_t> { const static NPY_TYPES type = NPY_INT64; };
-template <> struct select_npy_type<uint8_t> { const static NPY_TYPES type = NPY_UINT8; };
-template <> struct select_npy_type<uint16_t> { const static NPY_TYPES type = NPY_USHORT; };
-template <> struct select_npy_type<uint32_t> { const static NPY_TYPES type = NPY_ULONG; };
-template <> struct select_npy_type<uint64_t> { const static NPY_TYPES type = NPY_UINT64; };
+template <typename T> struct select_npy_type {
+  const static NPY_TYPES type = NPY_NOTYPE;
+}; // Default
+template <> struct select_npy_type<double> {
+  const static NPY_TYPES type = NPY_DOUBLE;
+};
+template <> struct select_npy_type<float> {
+  const static NPY_TYPES type = NPY_FLOAT;
+};
+template <> struct select_npy_type<bool> {
+  const static NPY_TYPES type = NPY_BOOL;
+};
+template <> struct select_npy_type<int8_t> {
+  const static NPY_TYPES type = NPY_INT8;
+};
+template <> struct select_npy_type<int16_t> {
+  const static NPY_TYPES type = NPY_SHORT;
+};
+template <> struct select_npy_type<int32_t> {
+  const static NPY_TYPES type = NPY_INT;
+};
+template <> struct select_npy_type<int64_t> {
+  const static NPY_TYPES type = NPY_INT64;
+};
+template <> struct select_npy_type<uint8_t> {
+  const static NPY_TYPES type = NPY_UINT8;
+};
+template <> struct select_npy_type<uint16_t> {
+  const static NPY_TYPES type = NPY_USHORT;
+};
+template <> struct select_npy_type<uint32_t> {
+  const static NPY_TYPES type = NPY_ULONG;
+};
+template <> struct select_npy_type<uint64_t> {
+  const static NPY_TYPES type = NPY_UINT64;
+};
 
 template <typename Numeric> PyObject *get_array(const std::vector<Numeric> &v) {
   detail::_interpreter::get(); // interpreter needs to be initialized for the numpy commands to work
@@ -1659,7 +1683,9 @@ template <typename T> using is_function = typename std::is_function<std::remove_
 
 template <bool obj, typename T> struct is_callable_impl;
 
-template <typename T> struct is_callable_impl<false, T> { typedef is_function<T> type; }; // a non-object is callable iff it is a function
+template <typename T> struct is_callable_impl<false, T> {
+  typedef is_function<T> type;
+}; // a non-object is callable iff it is a function
 
 template <typename T> struct is_callable_impl<true, T> {
   struct Fallback {

--- a/ov_core/src/track/TrackAruco.cpp
+++ b/ov_core/src/track/TrackAruco.cpp
@@ -94,7 +94,7 @@ void TrackAruco::perform_tracking(double timestamp, const cv::Mat &imgin, size_t
   //===================================================================================
 
   // Perform extraction
-#if CV_MAJOR_VERSION > 4 || ( CV_MAJOR_VERSION == 4 && CV_MINOR_VERSION >= 7)
+#if CV_MAJOR_VERSION > 4 || (CV_MAJOR_VERSION == 4 && CV_MINOR_VERSION >= 7)
   aruco_detector.detectMarkers(img0, corners[cam_id], ids_aruco[cam_id], rejects[cam_id]);
 #else
   cv::aruco::detectMarkers(img0, aruco_dict, corners[cam_id], ids_aruco[cam_id], aruco_params, rejects[cam_id]);

--- a/ov_core/src/track/TrackAruco.h
+++ b/ov_core/src/track/TrackAruco.h
@@ -55,7 +55,7 @@ public:
                       bool downsize)
       : TrackBase(cameras, 0, numaruco, stereo, histmethod), max_tag_id(numaruco), do_downsizing(downsize) {
 #if ENABLE_ARUCO_TAGS
-#if CV_MAJOR_VERSION > 4 || ( CV_MAJOR_VERSION == 4 && CV_MINOR_VERSION >= 7)
+#if CV_MAJOR_VERSION > 4 || (CV_MAJOR_VERSION == 4 && CV_MINOR_VERSION >= 7)
     aruco_dict = cv::aruco::getPredefinedDictionary(cv::aruco::DICT_6X6_1000);
     aruco_params.cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
     aruco_detector = cv::aruco::ArucoDetector(aruco_dict, aruco_params);
@@ -107,7 +107,7 @@ protected:
   bool do_downsizing;
 
 #if ENABLE_ARUCO_TAGS
-#if CV_MAJOR_VERSION > 4 || ( CV_MAJOR_VERSION == 4 && CV_MINOR_VERSION >= 7)
+#if CV_MAJOR_VERSION > 4 || (CV_MAJOR_VERSION == 4 && CV_MINOR_VERSION >= 7)
   // Our dictionary that we will extract aruco tags with
   cv::aruco::Dictionary aruco_dict;
   // Parameters the opencv extractor uses
@@ -120,7 +120,6 @@ protected:
   // Parameters the opencv extractor uses
   cv::Ptr<cv::aruco::DetectorParameters> aruco_params;
 #endif
-
 
   // Our tag IDs and corner we will get from the extractor
   std::unordered_map<size_t, std::vector<int>> ids_aruco;

--- a/ov_init/src/ceres/State_JPLQuatLocal.h
+++ b/ov_init/src/ceres/State_JPLQuatLocal.h
@@ -56,10 +56,10 @@ public:
   bool PlusJacobian(const double *x, double *jacobian) const override;
 
   // Inverse update: delta = Log(q2 ⊗ inv(q1))
-  bool Minus(const double* y, const double* x, double* delta) const override;
+  bool Minus(const double *y, const double *x, double *delta) const override;
 
   // Jacobian of Minus
-  bool MinusJacobian(const double* x, double* jacobian) const override;
+  bool MinusJacobian(const double *x, double *jacobian) const override;
 
   int AmbientSize() const override { return 4; }
   int TangentSize() const override { return 3; }
@@ -84,7 +84,6 @@ public:
   int LocalSize() const override { return 3; };
 
 #endif
-
 };
 
 } // namespace ov_init

--- a/ov_init/src/dynamic/DynamicInitializer.cpp
+++ b/ov_init/src/dynamic/DynamicInitializer.cpp
@@ -371,8 +371,8 @@ bool DynamicInitializer::initialize(double &timestamp, Eigen::MatrixXd &covarian
         } else {
           H_i.block(0, size_feature * A_index_features.at(feat.first), 2, 3) = Y; // feat
         }
-        H_i.block(0, size_feature * num_features + 0, 2, 3) = -DT * Y;            // vel
-        H_i.block(0, size_feature * num_features + 3, 2, 3) = 0.5 * DT * DT * Y;  // grav
+        H_i.block(0, size_feature * num_features + 0, 2, 3) = -DT * Y;           // vel
+        H_i.block(0, size_feature * num_features + 3, 2, 3) = 0.5 * DT * DT * Y; // grav
 
         // Else lets append this to our system!
         A.block(index_meas, 0, 2, A.cols()) = H_i;

--- a/ov_msckf/CMakeLists.txt
+++ b/ov_msckf/CMakeLists.txt
@@ -24,12 +24,6 @@ else ()
     add_definitions(-DENABLE_ARUCO_TAGS=1)
 endif ()
 
-# We need c++14 for ROS2, thus just require it for everybody
-# NOTE: To future self, hope this isn't an issue...
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 # Enable compile optimizations
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")
 

--- a/ov_msckf/launch/display_ros2.rviz
+++ b/ov_msckf/launch/display_ros2.rviz
@@ -3,14 +3,16 @@ Panels:
     Help Height: 0
     Name: Displays
     Property Tree Widget:
-      Expanded: ~
+      Expanded:
+        - /Pose1/Topic1
+        - /Image1
+        - /Image2
       Splitter Ratio: 0.4882352948188782
-    Tree Height: 272
+    Tree Height: 177
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
     Expanded:
-      - /2D Nav Goal1
       - /Publish Point1
     Name: Tool Properties
     Splitter Ratio: 0.5886790156364441
@@ -45,13 +47,9 @@ Visualization Manager:
       Frame Timeout: 120
       Frames:
         All Enabled: true
-        cam0:
-          Value: true
         global:
           Value: true
-        imu:
-          Value: true
-        truth:
+        gt_frame:
           Value: true
       Marker Scale: 1
       Name: TF
@@ -60,10 +58,7 @@ Visualization Manager:
       Show Names: true
       Tree:
         global:
-          imu:
-            cam0:
-              {}
-          truth:
+          gt_frame:
             {}
       Update Interval: 0
       Value: true
@@ -74,9 +69,12 @@ Visualization Manager:
       Min Value: 0
       Name: Image Tracks
       Normalize Range: true
-      Queue Size: 10
-      Topic: /ov_msckf/trackhist
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ov_msckf/trackhist
       Value: true
     - Class: rviz_default_plugins/Image
       Enabled: false
@@ -85,9 +83,12 @@ Visualization Manager:
       Min Value: 0
       Name: Current Depths
       Normalize Range: true
-      Queue Size: 10
-      Topic: /ov_msckf/loop_depth_colored
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ov_msckf/loop_depth_colored
       Value: false
     - Alpha: 1
       Buffer Length: 1
@@ -109,8 +110,13 @@ Visualization Manager:
       Radius: 0.029999999329447746
       Shaft Diameter: 0.10000000149011612
       Shaft Length: 0.10000000149011612
-      Topic: /ov_msckf/pathimu
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ov_msckf/pathimu
       Value: true
     - Alpha: 1
       Buffer Length: 1
@@ -132,8 +138,13 @@ Visualization Manager:
       Radius: 0.029999999329447746
       Shaft Diameter: 0.10000000149011612
       Shaft Length: 0.10000000149011612
-      Topic: /ov_msckf/pathgt
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /gt_path
       Value: true
     - Alpha: 0.800000011920929
       Autocompute Intensity Bounds: true
@@ -155,13 +166,17 @@ Visualization Manager:
       Min Intensity: 0
       Name: MSCKF Points
       Position Transformer: XYZ
-      Queue Size: 10
       Selectable: true
       Size (Pixels): 8
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /ov_msckf/points_msckf
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ov_msckf/points_msckf
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
@@ -185,13 +200,17 @@ Visualization Manager:
       Min Intensity: 0
       Name: SLAM Points
       Position Transformer: XYZ
-      Queue Size: 10
       Selectable: true
       Size (Pixels): 8
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /ov_msckf/points_slam
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ov_msckf/points_slam
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
@@ -215,13 +234,17 @@ Visualization Manager:
       Min Intensity: 0
       Name: ARUCO Points
       Position Transformer: XYZ
-      Queue Size: 10
       Selectable: true
       Size (Pixels): 15
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /ov_msckf/points_aruco
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ov_msckf/points_aruco
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
@@ -245,13 +268,17 @@ Visualization Manager:
       Min Intensity: 0
       Name: ACTIVE Points
       Position Transformer: XYZ
-      Queue Size: 10
       Selectable: true
       Size (Pixels): 3
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /ov_msckf/loop_feats
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ov_msckf/loop_feats
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
@@ -275,15 +302,67 @@ Visualization Manager:
       Min Intensity: 0
       Name: SIM Points
       Position Transformer: XYZ
-      Queue Size: 10
       Selectable: true
       Size (Pixels): 3
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /ov_msckf/points_sim
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ov_msckf/points_sim
       Use Fixed Frame: true
       Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Class: rviz_default_plugins/Pose
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.30000001192092896
+      Head Radius: 0.10000000149011612
+      Name: Pose
+      Shaft Length: 1
+      Shaft Radius: 0.05000000074505806
+      Shape: Arrow
+      Topic:
+        Depth: 1000
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep All
+        Reliability Policy: Reliable
+        Value: /odometry
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /cam0/masked
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /cam0/segmentation
       Value: true
   Enabled: true
   Global Options:
@@ -298,12 +377,30 @@ Visualization Manager:
     - Class: rviz_default_plugins/Measure
       Line color: 128; 128; 0
     - Class: rviz_default_plugins/SetInitialPose
-      Topic: /initialpose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
     - Class: rviz_default_plugins/SetGoal
-      Topic: /move_base_simple/goal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /move_base_simple/goal
     - Class: rviz_default_plugins/PublishPoint
       Single click: true
-      Topic: /clicked_point
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
   Transformation:
     Current:
       Class: rviz_default_plugins/TF
@@ -311,7 +408,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 10
+      Distance: 32.85626220703125
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
@@ -336,18 +433,20 @@ Window Geometry:
     collapsed: false
   Displays:
     collapsed: false
-  Height: 690
+  Height: 730
   Hide Left Dock: false
   Hide Right Dock: true
+  Image:
+    collapsed: false
   Image Tracks:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000258fc020000000bfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000014d000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000180049006d00610067006500200054007200610063006b00730100000190000001050000002800fffffffb0000000a0049006d00610067006501000001c60000011c0000000000000000fb0000001c00430075007200720065006e0074002000440065007000740068007300000001eb000000b50000002800ffffff000000010000010f00000218fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000218000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d006501000000000000045000000000000000000000039b0000025800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000280fc020000000dfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000000ee000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000180049006d00610067006500200054007200610063006b007301000001310000006a0000002800fffffffb0000000a0049006d00610067006501000001a10000008c0000002800fffffffb0000001c00430075007200720065006e00740020004400650070007400680073000000020c0000007d0000002800fffffffb0000000a0049006d00610067006501000002330000008a0000002800fffffffb0000000a0049006d00610067006501000001f4000000a10000000000000000000000010000010f00000218fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000218000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000003470000028000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Tool Properties:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1291
-  X: 2051
-  Y: 110
+  Width: 1207
+  X: 272
+  Y: 92

--- a/ov_msckf/src/core/VioManager.cpp
+++ b/ov_msckf/src/core/VioManager.cpp
@@ -153,6 +153,8 @@ VioManager::VioManager(VioManagerOptions &params_) : thread_init_running(false),
 
   // Make the updater!
   updaterMSCKF = std::make_shared<UpdaterMSCKF>(params.msckf_options, params.featinit_options);
+  updaterMSCKF->set_imu_residual_params(params.use_imu_residual, params.imu_residual_alpha, params.imu_residual_sigma_px);
+  updaterMSCKF->set_feature_logger_params(params.log_features, params.log_features_path);
   updaterSLAM = std::make_shared<UpdaterSLAM>(params.slam_options, params.aruco_options, params.featinit_options);
 
   // If we are using zero velocity updates, then create the updater
@@ -320,6 +322,12 @@ void VioManager::track_image_and_update(const ov_core::CameraData &message_const
   do_feature_propagate_update(message);
 }
 
+// ---------------------------------------------------------------------------
+// IMU residual: per-feature noise multiplier using stereo depth + clone poses
+// For each MSCKF feature, back-project from oldest clone using stereo depth,
+// propagate to newest clone using IMU-propagated camera poses, compare to
+// actual observation. High reprojection residual → dynamic feature → inflate noise.
+// ---------------------------------------------------------------------------
 void VioManager::do_feature_propagate_update(const ov_core::CameraData &message) {
 
   //===================================================================================

--- a/ov_msckf/src/core/VioManager.cpp
+++ b/ov_msckf/src/core/VioManager.cpp
@@ -155,7 +155,8 @@ VioManager::VioManager(VioManagerOptions &params_) : thread_init_running(false),
   updaterMSCKF = std::make_shared<UpdaterMSCKF>(params.msckf_options, params.featinit_options);
   updaterMSCKF->set_imu_residual_params(params.use_imu_residual, params.imu_residual_alpha, params.imu_residual_sigma_px,
                                          params.use_residual_variance, params.imu_residual_max_depth,
-                                         params.imu_residual_max_tri_error, params.imu_residual_dead_zone);
+                                         params.imu_residual_max_tri_error, params.imu_residual_dead_zone,
+                                         params.imu_residual_init_delay);
   updaterSLAM = std::make_shared<UpdaterSLAM>(params.slam_options, params.aruco_options, params.featinit_options);
 
   // If we are using zero velocity updates, then create the updater

--- a/ov_msckf/src/core/VioManager.cpp
+++ b/ov_msckf/src/core/VioManager.cpp
@@ -155,7 +155,7 @@ VioManager::VioManager(VioManagerOptions &params_) : thread_init_running(false),
   updaterMSCKF = std::make_shared<UpdaterMSCKF>(params.msckf_options, params.featinit_options);
   updaterMSCKF->set_imu_residual_params(params.use_imu_residual, params.imu_residual_alpha, params.imu_residual_sigma_px,
                                          params.use_residual_variance, params.imu_residual_max_depth,
-                                         params.imu_residual_max_tri_error);
+                                         params.imu_residual_max_tri_error, params.imu_residual_dead_zone);
   updaterSLAM = std::make_shared<UpdaterSLAM>(params.slam_options, params.aruco_options, params.featinit_options);
 
   // If we are using zero velocity updates, then create the updater

--- a/ov_msckf/src/core/VioManager.cpp
+++ b/ov_msckf/src/core/VioManager.cpp
@@ -154,7 +154,8 @@ VioManager::VioManager(VioManagerOptions &params_) : thread_init_running(false),
   // Make the updater!
   updaterMSCKF = std::make_shared<UpdaterMSCKF>(params.msckf_options, params.featinit_options);
   updaterMSCKF->set_imu_residual_params(params.use_imu_residual, params.imu_residual_alpha, params.imu_residual_sigma_px,
-                                         params.use_residual_variance, params.imu_residual_max_depth);
+                                         params.use_residual_variance, params.imu_residual_max_depth,
+                                         params.imu_residual_max_tri_error);
   updaterSLAM = std::make_shared<UpdaterSLAM>(params.slam_options, params.aruco_options, params.featinit_options);
 
   // If we are using zero velocity updates, then create the updater

--- a/ov_msckf/src/core/VioManager.cpp
+++ b/ov_msckf/src/core/VioManager.cpp
@@ -153,8 +153,8 @@ VioManager::VioManager(VioManagerOptions &params_) : thread_init_running(false),
 
   // Make the updater!
   updaterMSCKF = std::make_shared<UpdaterMSCKF>(params.msckf_options, params.featinit_options);
-  updaterMSCKF->set_imu_residual_params(params.use_imu_residual, params.imu_residual_alpha, params.imu_residual_sigma_px);
-  updaterMSCKF->set_feature_logger_params(params.log_features, params.log_features_path);
+  updaterMSCKF->set_imu_residual_params(params.use_imu_residual, params.imu_residual_alpha, params.imu_residual_sigma_px,
+                                         params.use_residual_variance, params.imu_residual_max_depth);
   updaterSLAM = std::make_shared<UpdaterSLAM>(params.slam_options, params.aruco_options, params.featinit_options);
 
   // If we are using zero velocity updates, then create the updater

--- a/ov_msckf/src/core/VioManagerOptions.h
+++ b/ov_msckf/src/core/VioManagerOptions.h
@@ -119,6 +119,12 @@ struct VioManagerOptions {
   /// For VIODE (baseline=5cm, fx=376px): depth 15m → 1.3px disparity (unreliable).
   double imu_residual_max_depth = 0.0;
 
+  /// Triangulation quality gate (pixels).  If the RMS reprojection error of p_FinG
+  /// across all sliding-window clones exceeds this threshold, nm is suppressed to 1.0.
+  /// Prevents false nm inflation when triangulation is unreliable (e.g. low-texture night).
+  /// 0 = disabled (default).
+  double imu_residual_max_tri_error = 0.0;
+
   /**
    * @brief This function will load print out all estimator settings loaded.
    * This allows for visual checking that everything was loaded properly from ROS/CMD parsers.
@@ -143,11 +149,12 @@ struct VioManagerOptions {
       parser->parse_config("imu_residual_sigma_px", imu_residual_sigma_px);
       parser->parse_config("use_residual_variance", use_residual_variance);
       parser->parse_config("imu_residual_max_depth", imu_residual_max_depth);
+      parser->parse_config("imu_residual_max_tri_error", imu_residual_max_tri_error);
     }
     PRINT_DEBUG("  - dt_slam_delay: %.1f\n", dt_slam_delay);
-    PRINT_DEBUG("  - use_imu_residual: %d  alpha=%.1f  sigma_px=%.1f  variance=%d  max_depth=%.1f\n",
+    PRINT_DEBUG("  - use_imu_residual: %d  alpha=%.1f  sigma_px=%.1f  variance=%d  max_depth=%.1f  max_tri_error=%.1f\n",
                 (int)use_imu_residual, imu_residual_alpha, imu_residual_sigma_px,
-                (int)use_residual_variance, imu_residual_max_depth);
+                (int)use_residual_variance, imu_residual_max_depth, imu_residual_max_tri_error);
     PRINT_DEBUG("  - zero_velocity_update: %d\n", try_zupt);
     PRINT_DEBUG("  - zupt_max_velocity: %.2f\n", zupt_max_velocity);
     PRINT_DEBUG("  - zupt_noise_multiplier: %.2f\n", zupt_noise_multiplier);

--- a/ov_msckf/src/core/VioManagerOptions.h
+++ b/ov_msckf/src/core/VioManagerOptions.h
@@ -131,6 +131,12 @@ struct VioManagerOptions {
   /// Default 3.0 (= 4.5 px for sigma_pix=1.5).  Set to 0.0 to disable the dead zone.
   double imu_residual_dead_zone = 3.0;
 
+  /// Seconds after initialization before nm activation begins.
+  /// During this window every feature receives nm=1 so that early IMU bias uncertainty
+  /// (ba/bg not yet converged) does not cause false noise inflation on static features.
+  /// 0.0 = disabled (nm active immediately, original behaviour).
+  double imu_residual_init_delay = 0.0;
+
   /**
    * @brief This function will load print out all estimator settings loaded.
    * This allows for visual checking that everything was loaded properly from ROS/CMD parsers.
@@ -157,11 +163,12 @@ struct VioManagerOptions {
       parser->parse_config("imu_residual_max_depth", imu_residual_max_depth);
       parser->parse_config("imu_residual_max_tri_error", imu_residual_max_tri_error);
       parser->parse_config("imu_residual_dead_zone", imu_residual_dead_zone);
+      parser->parse_config("imu_residual_init_delay", imu_residual_init_delay);
     }
     PRINT_DEBUG("  - dt_slam_delay: %.1f\n", dt_slam_delay);
-    PRINT_DEBUG("  - use_imu_residual: %d  alpha=%.1f  sigma_px=%.1f  variance=%d  max_depth=%.1f  max_tri_error=%.1f  dead_zone=%.1f\n",
+    PRINT_DEBUG("  - use_imu_residual: %d  alpha=%.1f  sigma_px=%.1f  variance=%d  max_depth=%.1f  max_tri_error=%.1f  dead_zone=%.1f  init_delay=%.1fs\n",
                 (int)use_imu_residual, imu_residual_alpha, imu_residual_sigma_px,
-                (int)use_residual_variance, imu_residual_max_depth, imu_residual_max_tri_error, imu_residual_dead_zone);
+                (int)use_residual_variance, imu_residual_max_depth, imu_residual_max_tri_error, imu_residual_dead_zone, imu_residual_init_delay);
     PRINT_DEBUG("  - zero_velocity_update: %d\n", try_zupt);
     PRINT_DEBUG("  - zupt_max_velocity: %.2f\n", zupt_max_velocity);
     PRINT_DEBUG("  - zupt_noise_multiplier: %.2f\n", zupt_noise_multiplier);

--- a/ov_msckf/src/core/VioManagerOptions.h
+++ b/ov_msckf/src/core/VioManagerOptions.h
@@ -100,6 +100,23 @@ struct VioManagerOptions {
   /// The path to the file we will record the timing information into
   std::string record_timing_filepath = "ov_msckf_timing.txt";
 
+  /// If we should use IMU-residual per-feature noise inflation (Phase 1)
+  bool use_imu_residual = false;
+
+  /// Noise inflation scale: sigma^2_obs(i) = sigma^2_base * (1 + alpha * (1 - s_imu))
+  double imu_residual_alpha = 5.0;
+
+  /// Residual threshold in pixels for s_imu = exp(-r_px / sigma_px)
+  double imu_residual_sigma_px = 2.0;
+
+  /// Enable per-feature CSV logging for JEPA dataset construction (Phase 2).
+  /// Disabled by default — zero runtime cost when false.
+  bool log_features = false;
+
+  /// Output path for the feature log CSV (e.g. /data/logs/feature_log_run_1.csv).
+  /// The run number should be embedded by the calling script; not auto-incremented here.
+  std::string log_features_path = "";
+
   /**
    * @brief This function will load print out all estimator settings loaded.
    * This allows for visual checking that everything was loaded properly from ROS/CMD parsers.
@@ -119,8 +136,15 @@ struct VioManagerOptions {
       parser->parse_config("zupt_only_at_beginning", zupt_only_at_beginning);
       parser->parse_config("record_timing_information", record_timing_information);
       parser->parse_config("record_timing_filepath", record_timing_filepath);
+      parser->parse_config("use_imu_residual", use_imu_residual);
+      parser->parse_config("imu_residual_alpha", imu_residual_alpha);
+      parser->parse_config("imu_residual_sigma_px", imu_residual_sigma_px);
+      parser->parse_config("log_features", log_features);
+      parser->parse_config("log_features_path", log_features_path);
     }
     PRINT_DEBUG("  - dt_slam_delay: %.1f\n", dt_slam_delay);
+    PRINT_DEBUG("  - use_imu_residual: %d  alpha=%.1f  sigma_px=%.1f\n", (int)use_imu_residual, imu_residual_alpha, imu_residual_sigma_px);
+    PRINT_DEBUG("  - log_features: %d  path=%s\n", (int)log_features, log_features_path.c_str());
     PRINT_DEBUG("  - zero_velocity_update: %d\n", try_zupt);
     PRINT_DEBUG("  - zupt_max_velocity: %.2f\n", zupt_max_velocity);
     PRINT_DEBUG("  - zupt_noise_multiplier: %.2f\n", zupt_noise_multiplier);

--- a/ov_msckf/src/core/VioManagerOptions.h
+++ b/ov_msckf/src/core/VioManagerOptions.h
@@ -125,6 +125,12 @@ struct VioManagerOptions {
   /// 0 = disabled (default).
   double imu_residual_max_tri_error = 0.0;
 
+  /// Dead-zone multiplier for the single-frame nm mode.
+  /// noise_floor = imu_residual_dead_zone * sigma_pix.  Residuals below this floor are
+  /// treated as zero so static features with small triangulation bias do not get inflated.
+  /// Default 3.0 (= 4.5 px for sigma_pix=1.5).  Set to 0.0 to disable the dead zone.
+  double imu_residual_dead_zone = 3.0;
+
   /**
    * @brief This function will load print out all estimator settings loaded.
    * This allows for visual checking that everything was loaded properly from ROS/CMD parsers.
@@ -150,11 +156,12 @@ struct VioManagerOptions {
       parser->parse_config("use_residual_variance", use_residual_variance);
       parser->parse_config("imu_residual_max_depth", imu_residual_max_depth);
       parser->parse_config("imu_residual_max_tri_error", imu_residual_max_tri_error);
+      parser->parse_config("imu_residual_dead_zone", imu_residual_dead_zone);
     }
     PRINT_DEBUG("  - dt_slam_delay: %.1f\n", dt_slam_delay);
-    PRINT_DEBUG("  - use_imu_residual: %d  alpha=%.1f  sigma_px=%.1f  variance=%d  max_depth=%.1f  max_tri_error=%.1f\n",
+    PRINT_DEBUG("  - use_imu_residual: %d  alpha=%.1f  sigma_px=%.1f  variance=%d  max_depth=%.1f  max_tri_error=%.1f  dead_zone=%.1f\n",
                 (int)use_imu_residual, imu_residual_alpha, imu_residual_sigma_px,
-                (int)use_residual_variance, imu_residual_max_depth, imu_residual_max_tri_error);
+                (int)use_residual_variance, imu_residual_max_depth, imu_residual_max_tri_error, imu_residual_dead_zone);
     PRINT_DEBUG("  - zero_velocity_update: %d\n", try_zupt);
     PRINT_DEBUG("  - zupt_max_velocity: %.2f\n", zupt_max_velocity);
     PRINT_DEBUG("  - zupt_noise_multiplier: %.2f\n", zupt_noise_multiplier);

--- a/ov_msckf/src/core/VioManagerOptions.h
+++ b/ov_msckf/src/core/VioManagerOptions.h
@@ -100,22 +100,24 @@ struct VioManagerOptions {
   /// The path to the file we will record the timing information into
   std::string record_timing_filepath = "ov_msckf_timing.txt";
 
-  /// If we should use IMU-residual per-feature noise inflation (Phase 1)
+  /// If we should use IMU-residual per-feature noise inflation
   bool use_imu_residual = false;
 
-  /// Noise inflation scale: sigma^2_obs(i) = sigma^2_base * (1 + alpha * (1 - s_imu))
+  /// Noise inflation scale: nm = 1 + alpha * (1 - exp(-signal / sigma_px))
   double imu_residual_alpha = 5.0;
 
-  /// Residual threshold in pixels for s_imu = exp(-r_px / sigma_px)
+  /// Decay constant in pixels for the exponential nm formula
   double imu_residual_sigma_px = 2.0;
 
-  /// Enable per-feature CSV logging for JEPA dataset construction (Phase 2).
-  /// Disabled by default — zero runtime cost when false.
-  bool log_features = false;
+  /// Use cross-clone residual std-dev (variance mode) instead of single-frame residual.
+  /// Variance is bias-invariant: triangulation error offsets cancel, only moving features
+  /// show high std_r.  Requires ≥3 valid clone observations; falls back to nm=1 for short tracks.
+  bool use_residual_variance = false;
 
-  /// Output path for the feature log CSV (e.g. /data/logs/feature_log_run_1.csv).
-  /// The run number should be embedded by the calling script; not auto-incremented here.
-  std::string log_features_path = "";
+  /// Depth gate for nm inflation (metres).  Features beyond this depth have low stereo
+  /// disparity → unreliable p_FinG → nm is suppressed to 1.0.  0 = disabled (default).
+  /// For VIODE (baseline=5cm, fx=376px): depth 15m → 1.3px disparity (unreliable).
+  double imu_residual_max_depth = 0.0;
 
   /**
    * @brief This function will load print out all estimator settings loaded.
@@ -139,12 +141,13 @@ struct VioManagerOptions {
       parser->parse_config("use_imu_residual", use_imu_residual);
       parser->parse_config("imu_residual_alpha", imu_residual_alpha);
       parser->parse_config("imu_residual_sigma_px", imu_residual_sigma_px);
-      parser->parse_config("log_features", log_features);
-      parser->parse_config("log_features_path", log_features_path);
+      parser->parse_config("use_residual_variance", use_residual_variance);
+      parser->parse_config("imu_residual_max_depth", imu_residual_max_depth);
     }
     PRINT_DEBUG("  - dt_slam_delay: %.1f\n", dt_slam_delay);
-    PRINT_DEBUG("  - use_imu_residual: %d  alpha=%.1f  sigma_px=%.1f\n", (int)use_imu_residual, imu_residual_alpha, imu_residual_sigma_px);
-    PRINT_DEBUG("  - log_features: %d  path=%s\n", (int)log_features, log_features_path.c_str());
+    PRINT_DEBUG("  - use_imu_residual: %d  alpha=%.1f  sigma_px=%.1f  variance=%d  max_depth=%.1f\n",
+                (int)use_imu_residual, imu_residual_alpha, imu_residual_sigma_px,
+                (int)use_residual_variance, imu_residual_max_depth);
     PRINT_DEBUG("  - zero_velocity_update: %d\n", try_zupt);
     PRINT_DEBUG("  - zupt_max_velocity: %.2f\n", zupt_max_velocity);
     PRINT_DEBUG("  - zupt_noise_multiplier: %.2f\n", zupt_noise_multiplier);

--- a/ov_msckf/src/core/VioManagerOptions.h
+++ b/ov_msckf/src/core/VioManagerOptions.h
@@ -219,6 +219,15 @@ struct VioManagerOptions {
   /// Mask images for each camera
   std::map<size_t, cv::Mat> masks;
 
+  /// If we should use dynamic masks from ROS topics
+  bool use_dynamic_mask = false;
+
+  /// ROS topic for left camera mask
+  std::string dynamic_mask_topic0 = "/mask0";
+
+  /// ROS topic for right camera mask
+  std::string dynamic_mask_topic1 = "/mask1";
+
   /**
    * @brief This function will load and print all state parameters (e.g. sensor extrinsics)
    * This allows for visual checking that everything was loaded properly from ROS/CMD parsers.
@@ -279,6 +288,16 @@ struct VioManagerOptions {
         camera_extrinsics.insert({i, cam_eigen});
       }
       parser->parse_config("use_mask", use_mask);
+      parser->parse_config("use_dynamic_mask", use_dynamic_mask);
+      parser->parse_config("dynamic_mask_topic0", dynamic_mask_topic0);
+      parser->parse_config("dynamic_mask_topic1", dynamic_mask_topic1);
+
+      PRINT_DEBUG("  - dynamic masks?: %d\n", use_dynamic_mask);
+      if (use_dynamic_mask) {
+        PRINT_DEBUG("  - dynamic mask topic 0: %s\n", dynamic_mask_topic0.c_str());
+        PRINT_DEBUG("  - dynamic mask topic 1: %s\n", dynamic_mask_topic1.c_str());
+      }
+
       if (use_mask) {
         for (int i = 0; i < state_options.num_cameras; i++) {
           std::string mask_path;

--- a/ov_msckf/src/ros/ROS1Visualizer.cpp
+++ b/ov_msckf/src/ros/ROS1Visualizer.cpp
@@ -169,27 +169,65 @@ void ROS1Visualizer::setup_subscribers(std::shared_ptr<ov_core::YamlParser> pars
     _nh->param<std::string>("topic_camera" + std::to_string(1), cam_topic1, "/cam" + std::to_string(1) + "/image_raw");
     parser->parse_external("relative_config_imucam", "cam" + std::to_string(0), "rostopic", cam_topic0);
     parser->parse_external("relative_config_imucam", "cam" + std::to_string(1), "rostopic", cam_topic1);
-    // Create sync filter (they have unique pointers internally, so we have to use move logic here...)
+
+    // Create image subscribers
     auto image_sub0 = std::make_shared<message_filters::Subscriber<sensor_msgs::Image>>(*_nh, cam_topic0, 1);
     auto image_sub1 = std::make_shared<message_filters::Subscriber<sensor_msgs::Image>>(*_nh, cam_topic1, 1);
-    auto sync = std::make_shared<message_filters::Synchronizer<sync_pol>>(sync_pol(10), *image_sub0, *image_sub1);
-    sync->registerCallback(boost::bind(&ROS1Visualizer::callback_stereo, this, _1, _2, 0, 1));
-    // Append to our vector of subscribers
-    sync_cam.push_back(sync);
-    sync_subs_cam.push_back(image_sub0);
-    sync_subs_cam.push_back(image_sub1);
-    PRINT_INFO("subscribing to cam (stereo): %s\n", cam_topic0.c_str());
-    PRINT_INFO("subscribing to cam (stereo): %s\n", cam_topic1.c_str());
+
+    // NEW LOGIC FOR DYNAMIC MASKS
+    if (_app->get_params().use_dynamic_mask) {
+      std::string mask_topic0 = _app->get_params().dynamic_mask_topic0;
+      std::string mask_topic1 = _app->get_params().dynamic_mask_topic1;
+      PRINT_INFO("subscribing to stereo masks: 	- %s	- %s", mask_topic0.c_str(), mask_topic1.c_str());
+
+      auto mask_sub0 = std::make_shared<message_filters::Subscriber<sensor_msgs::Image>>(*_nh, mask_topic0, 1);
+      auto mask_sub1 = std::make_shared<message_filters::Subscriber<sensor_msgs::Image>>(*_nh, mask_topic1, 1);
+
+      auto sync = std::make_shared<message_filters::Synchronizer<sync_pol_masks>>(sync_pol_masks(10), *image_sub0, *image_sub1, *mask_sub0,
+                                                                                  *mask_sub1);
+      sync->registerCallback(boost::bind(&ROS1Visualizer::callback_stereo_masks, this, _1, _2, _3, _4, 0, 1));
+
+      sync_cam_masks.push_back(sync);
+      sync_subs_cam.push_back(image_sub0);
+      sync_subs_cam.push_back(image_sub1);
+      sync_subs_cam.push_back(mask_sub0);
+      sync_subs_cam.push_back(mask_sub1);
+    } else {
+      // ORIGINAL LOGIC
+      auto sync = std::make_shared<message_filters::Synchronizer<sync_pol>>(sync_pol(10), *image_sub0, *image_sub1);
+      sync->registerCallback(boost::bind(&ROS1Visualizer::callback_stereo, this, _1, _2, 0, 1));
+      sync_cam.push_back(sync);
+      sync_subs_cam.push_back(image_sub0);
+      sync_subs_cam.push_back(image_sub1);
+    }
+    PRINT_INFO("subscribing to cam (stereo): %s", cam_topic0.c_str());
+    PRINT_INFO("subscribing to cam (stereo): %s", cam_topic1.c_str());
   } else {
     // Now we should add any non-stereo callbacks here
     for (int i = 0; i < _app->get_params().state_options.num_cameras; i++) {
-      // read in the topic
+      // Read in the camera topic
       std::string cam_topic;
-      _nh->param<std::string>("topic_camera" + std::to_string(i), cam_topic, "/cam" + std::to_string(i) + "/image_raw");
+      _node->declare_parameter<std::string>("topic_camera" + std::to_string(i), "/cam" + std::to_string(i) + "/image_raw");
+      _node->get_parameter("topic_camera" + std::to_string(i), cam_topic);
       parser->parse_external("relative_config_imucam", "cam" + std::to_string(i), "rostopic", cam_topic);
-      // create subscriber
-      subs_cam.push_back(_nh->subscribe<sensor_msgs::Image>(cam_topic, 10, boost::bind(&ROS1Visualizer::callback_monocular, this, _1, i)));
-      PRINT_INFO("subscribing to cam (mono): %s\n", cam_topic.c_str());
+
+      if (_app->get_params().use_dynamic_mask) {
+        std::string mask_topic = (i == 0) ? _app->get_params().dynamic_mask_topic0 : _app->get_params().dynamic_mask_topic1;
+        auto image_sub = std::make_shared<message_filters::Subscriber<sensor_msgs::Image>>(*_nh, cam_topic, 1);
+        auto mask_sub = std::make_shared<message_filters::Subscriber<sensor_msgs::Image>>(*_nh, mask_topic, 1);
+        auto sync = std::make_shared<message_filters::Synchronizer<sync_pol_mono_mask>>(sync_pol_mono_mask(10), *image_sub, *mask_sub);
+        sync->registerCallback(boost::bind(&ROS1Visualizer::callback_monocular_masks, this, _1, _2, i));
+        sync_cam_mono_masks.push_back(sync);
+        sync_subs_cam.push_back(image_sub);
+        sync_subs_cam.push_back(mask_sub);
+      } else {
+        // Original monocular logic
+        auto sub = _node->create_subscription<sensor_msgs::msg::Image>(
+            cam_topic, 10, [this, i](const sensor_msgs::msg::Image::SharedPtr msg0) { callback_monocular(msg0, i); });
+        subs_cam.push_back(sub);
+      }
+      PRINT_INFO("subscribing to cam (mono): %s
+", cam_topic.c_str());
     }
   }
 }
@@ -583,6 +621,137 @@ void ROS1Visualizer::callback_stereo(const sensor_msgs::ImageConstPtr &msg0, con
   }
 
   // append it to our queue of images
+  std::lock_guard<std::mutex> lck(camera_queue_mtx);
+  camera_queue.push_back(message);
+  std::sort(camera_queue.begin(), camera_queue.end());
+}
+
+void ROS1Visualizer::callback_stereo_masks(const sensor_msgs::ImageConstPtr &msg0, const sensor_msgs::ImageConstPtr &msg1,
+                                           const sensor_msgs::ImageConstPtr &mask0, const sensor_msgs::ImageConstPtr &mask1, int cam_id0,
+                                           int cam_id1) {
+
+  // Check if we should drop this image (throttling)
+  double timestamp = msg0->header.stamp.toSec();
+  double time_delta = 1.0 / _app->get_params().track_frequency;
+  if (camera_last_timestamp.find(cam_id0) != camera_last_timestamp.end() && timestamp < camera_last_timestamp.at(cam_id0) + time_delta) {
+    return;
+  }
+  camera_last_timestamp[cam_id0] = timestamp;
+
+  // Get the images and masks
+  cv_bridge::CvImageConstPtr cv_ptr0, cv_ptr1, cv_mask0, cv_mask1;
+  try {
+    cv_ptr0 = cv_bridge::toCvShare(msg0, sensor_msgs::image_encodings::MONO8);
+    cv_ptr1 = cv_bridge::toCvShare(msg1, sensor_msgs::image_encodings::MONO8);
+    cv_mask0 = cv_bridge::toCvShare(mask0, sensor_msgs::image_encodings::MONO8);
+    cv_mask1 = cv_bridge::toCvShare(mask1, sensor_msgs::image_encodings::MONO8);
+  } catch (cv_bridge::Exception &e) {
+    PRINT_ERROR("cv_bridge exception: %s
+", e.what());
+    return;
+  }
+
+  // Create the measurement
+  ov_core::CameraData message;
+  message.timestamp = cv_ptr0->header.stamp.toSec();
+  message.sensor_ids.push_back(cam_id0);
+  message.sensor_ids.push_back(cam_id1);
+  message.images.push_back(cv_ptr0->image.clone());
+  message.images.push_back(cv_ptr1->image.clone());
+
+  // === MASK COMBINATION LOGIC ===
+  // 1. Get the dynamic masks from ROS message
+  cv::Mat dyn_mask0 = cv_mask0->image;
+  cv::Mat dyn_mask1 = cv_mask1->image;
+
+  // 2. Get the static masks if enabled (from config)
+  cv::Mat final_mask0, final_mask1;
+
+  if (_app->get_params().use_mask) {
+    // Merge Static + Dynamic for Cam 0
+    cv::Mat static_mask0 = _app->get_params().masks.at(cam_id0);
+    if (!dyn_mask0.empty() && !static_mask0.empty()) {
+      cv::bitwise_or(dyn_mask0, static_mask0, final_mask0);
+    } else {
+      final_mask0 = dyn_mask0.empty() ? static_mask0 : dyn_mask0;
+    }
+
+    // Merge Static + Dynamic for Cam 1
+    cv::Mat static_mask1 = _app->get_params().masks.at(cam_id1);
+    if (!dyn_mask1.empty() && !static_mask1.empty()) {
+      cv::bitwise_or(dyn_mask1, static_mask1, final_mask1);
+    } else {
+      final_mask1 = dyn_mask1.empty() ? static_mask1 : dyn_mask1;
+    }
+  } else {
+    // Only use dynamic masks
+    final_mask0 = dyn_mask0.clone();
+    final_mask1 = dyn_mask1.clone();
+  }
+
+  // 3. Ensure we have valid masks (black if empty)
+  if (final_mask0.empty())
+    final_mask0 = cv::Mat::zeros(cv_ptr0->image.rows, cv_ptr0->image.cols, CV_8UC1);
+  if (final_mask1.empty())
+    final_mask1 = cv::Mat::zeros(cv_ptr1->image.rows, cv_ptr1->image.cols, CV_8UC1);
+
+  message.masks.push_back(final_mask0);
+  message.masks.push_back(final_mask1);
+  // ==============================
+
+  // Append to our queue of images
+  std::lock_guard<std::mutex> lck(camera_queue_mtx);
+  camera_queue.push_back(message);
+  std::sort(camera_queue.begin(), camera_queue.end());
+}
+
+void ROS1Visualizer::callback_monocular_masks(const sensor_msgs::msg::Image::ConstSharedPtr msg,
+                                              const sensor_msgs::msg::Image::ConstSharedPtr mask, int cam_id) {
+  // Throttling logic
+  double timestamp = msg->header.stamp.sec + msg->header.stamp.nanosec * 1e-9;
+  double time_delta = 1.0 / _app->get_params().track_frequency;
+  if (camera_last_timestamp.find(cam_id) != camera_last_timestamp.end() && timestamp < camera_last_timestamp.at(cam_id) + time_delta) {
+    return;
+  }
+  camera_last_timestamp[cam_id] = timestamp;
+
+  // Get image and mask
+  cv_bridge::CvImageConstPtr cv_ptr, cv_mask;
+  try {
+    cv_ptr = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::MONO8);
+    cv_mask = cv_bridge::toCvShare(mask, sensor_msgs::image_encodings::MONO8);
+  } catch (cv_bridge::Exception &e) {
+    PRINT_ERROR("cv_bridge exception: %s", e.what());
+    return;
+  }
+
+  // Create measurement
+  ov_core::CameraData message;
+  message.timestamp = timestamp;
+  message.sensor_ids.push_back(cam_id);
+  message.images.push_back(cv_ptr->image.clone());
+
+  // Merge static and dynamic masks
+  cv::Mat final_mask;
+  cv::Mat dyn_mask = cv_mask->image;
+  if (_app->get_params().use_mask) {
+    cv::Mat static_mask = _app->get_params().masks.at(cam_id);
+    if (!dyn_mask.empty() && !static_mask.empty()) {
+      if (dyn_mask.rows != static_mask.rows || dyn_mask.cols != static_mask.cols) {
+        PRINT_WARNING(YELLOW "Dynamic mask size mismatch for Cam! Resizing...\n" RESET);
+        cv::resize(dyn_mask, dyn_mask, static_mask.size(), 0, 0, cv::INTER_NEAREST);
+      }
+      cv::bitwise_or(dyn_mask, static_mask, final_mask);
+    } else {
+      final_mask = dyn_mask.empty() ? static_mask : dyn_mask;
+    }
+  } else {
+    final_mask = dyn_mask.clone();
+  }
+  if (final_mask.empty())
+    final_mask = cv::Mat::zeros(cv_ptr->image.rows, cv_ptr->image.cols, CV_8UC1);
+  message.masks.push_back(final_mask);
+
   std::lock_guard<std::mutex> lck(camera_queue_mtx);
   camera_queue.push_back(message);
   std::sort(camera_queue.begin(), camera_queue.end());

--- a/ov_msckf/src/ros/ROS1Visualizer.h
+++ b/ov_msckf/src/ros/ROS1Visualizer.h
@@ -114,6 +114,10 @@ public:
   /// Callback for synchronized stereo camera information
   void callback_stereo(const sensor_msgs::ImageConstPtr &msg0, const sensor_msgs::ImageConstPtr &msg1, int cam_id0, int cam_id1);
 
+  /// Callback for synchronized stereo camera information WITH dynamic masks
+  void callback_stereo_masks(const sensor_msgs::ImageConstPtr &msg0, const sensor_msgs::ImageConstPtr &msg1,
+                             const sensor_msgs::ImageConstPtr &mask0, const sensor_msgs::ImageConstPtr &mask1, int cam_id0, int cam_id1);
+
 protected:
   /// Publish the current state
   void publish_state();
@@ -150,8 +154,15 @@ protected:
   ros::Subscriber sub_imu;
   std::vector<ros::Subscriber> subs_cam;
   typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::Image> sync_pol;
+  typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::Image>
+      sync_pol_masks;
+  typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::msg::Image, sensor_msgs::msg::Image> sync_pol_mono_mask;
   std::vector<std::shared_ptr<message_filters::Synchronizer<sync_pol>>> sync_cam;
+  std::vector<std::shared_ptr<message_filters::Synchronizer<sync_pol_masks>>> sync_cam_masks;
+  std::vector<std::shared_ptr<message_filters::Synchronizer<sync_pol_mono_mask>>> sync_cam_mono_masks;
   std::vector<std::shared_ptr<message_filters::Subscriber<sensor_msgs::Image>>> sync_subs_cam;
+  void callback_monocular_masks(const sensor_msgs::msg::Image::ConstSharedPtr msg, const sensor_msgs::msg::Image::ConstSharedPtr mask,
+                                int cam_id);
 
   // For path viz
   unsigned int poses_seq_imu = 0;

--- a/ov_msckf/src/ros/ROS2Visualizer.cpp
+++ b/ov_msckf/src/ros/ROS2Visualizer.cpp
@@ -36,13 +36,10 @@ using namespace ov_type;
 using namespace ov_msckf;
 
 ROS2Visualizer::ROS2Visualizer(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<VioManager> app, std::shared_ptr<Simulator> sim)
-    : _node(node), _app(app), _sim(sim), thread_update_running(false) {
+    : _node(node), _app(app), _sim(sim), _it(node), thread_update_running(false) {
 
   // Setup our transform broadcaster
   mTfBr = std::make_shared<tf2_ros::TransformBroadcaster>(node);
-
-  // Create image transport
-  image_transport::ImageTransport it(node);
 
   // Setup pose and path publisher
   pub_poseimu = node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("poseimu", 2);
@@ -63,7 +60,7 @@ ROS2Visualizer::ROS2Visualizer(std::shared_ptr<rclcpp::Node> node, std::shared_p
   PRINT_DEBUG("Publishing: %s\n", pub_points_sim->get_topic_name());
 
   // Our tracking image
-  it_pub_tracks = it.advertise("trackhist", 2);
+  it_pub_tracks = _it.advertise("trackhist", 2);
   PRINT_DEBUG("Publishing: %s\n", it_pub_tracks.getTopic().c_str());
 
   // Groundtruth publishers
@@ -77,8 +74,8 @@ ROS2Visualizer::ROS2Visualizer(std::shared_ptr<rclcpp::Node> node, std::shared_p
   pub_loop_point = node->create_publisher<sensor_msgs::msg::PointCloud>("loop_feats", 2);
   pub_loop_extrinsic = node->create_publisher<nav_msgs::msg::Odometry>("loop_extrinsic", 2);
   pub_loop_intrinsics = node->create_publisher<sensor_msgs::msg::CameraInfo>("loop_intrinsics", 2);
-  it_pub_loop_img_depth = it.advertise("loop_depth", 2);
-  it_pub_loop_img_depth_color = it.advertise("loop_depth_colored", 2);
+  it_pub_loop_img_depth = _it.advertise("loop_depth", 2);
+  it_pub_loop_img_depth_color = _it.advertise("loop_depth_colored", 2);
 
   // option to enable publishing of global to IMU transformation
   if (node->has_parameter("publish_global_to_imu_tf")) {

--- a/ov_msckf/src/ros/ROS2Visualizer.cpp
+++ b/ov_msckf/src/ros/ROS2Visualizer.cpp
@@ -185,35 +185,71 @@ void ROS2Visualizer::setup_subscribers(std::shared_ptr<ov_core::YamlParser> pars
     _node->get_parameter("topic_camera" + std::to_string(1), cam_topic1);
     parser->parse_external("relative_config_imucam", "cam" + std::to_string(0), "rostopic", cam_topic0);
     parser->parse_external("relative_config_imucam", "cam" + std::to_string(1), "rostopic", cam_topic1);
+
     // Create sync filter (they have unique pointers internally, so we have to use move logic here...)
     auto image_sub0 = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(_node, cam_topic0);
     auto image_sub1 = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(_node, cam_topic1);
-    auto sync = std::make_shared<message_filters::Synchronizer<sync_pol>>(sync_pol(10), *image_sub0, *image_sub1);
-    sync->registerCallback(std::bind(&ROS2Visualizer::callback_stereo, this, std::placeholders::_1, std::placeholders::_2, 0, 1));
-    // sync->registerCallback([](const sensor_msgs::msg::Image::SharedPtr msg0, const sensor_msgs::msg::Image::SharedPtr msg1)
-    // {callback_stereo(msg0, msg1, 0, 1);});
-    // sync->registerCallback(&callback_stereo2); // since the above two alternatives fail to compile for some reason
-    // Append to our vector of subscribers
-    sync_cam.push_back(sync);
-    sync_subs_cam.push_back(image_sub0);
-    sync_subs_cam.push_back(image_sub1);
-    PRINT_INFO("subscribing to cam (stereo): %s\n", cam_topic0.c_str());
-    PRINT_INFO("subscribing to cam (stereo): %s\n", cam_topic1.c_str());
+
+    // NEW LOGIC FOR DYNAMIC MASKS
+    if (_app->get_params().use_dynamic_mask) {
+      std::string mask_topic0 = _app->get_params().dynamic_mask_topic0;
+      std::string mask_topic1 = _app->get_params().dynamic_mask_topic1;
+      PRINT_INFO("subscribing to stereo masks: - %s - %s", mask_topic0.c_str(), mask_topic1.c_str());
+
+      auto mask_sub0 = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(_node, mask_topic0);
+      auto mask_sub1 = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(_node, mask_topic1);
+
+      auto sync = std::make_shared<message_filters::Synchronizer<sync_pol_masks>>(sync_pol_masks(10), *image_sub0, *image_sub1, *mask_sub0,
+                                                                                  *mask_sub1);
+      sync->registerCallback(std::bind(&ROS2Visualizer::callback_stereo_masks, this, std::placeholders::_1, std::placeholders::_2,
+                                       std::placeholders::_3, std::placeholders::_4, 0, 1));
+
+      sync_cam_masks.push_back(sync);
+      sync_subs_cam.push_back(image_sub0);
+      sync_subs_cam.push_back(image_sub1);
+      sync_subs_cam.push_back(mask_sub0); // Keep mask subscribers alive
+      sync_subs_cam.push_back(mask_sub1);
+
+    } else {
+      // ORIGINAL LOGIC (No dynamic mask)
+      auto sync = std::make_shared<message_filters::Synchronizer<sync_pol>>(sync_pol(10), *image_sub0, *image_sub1);
+      sync->registerCallback(std::bind(&ROS2Visualizer::callback_stereo, this, std::placeholders::_1, std::placeholders::_2, 0, 1));
+      sync_cam.push_back(sync);
+      sync_subs_cam.push_back(image_sub0);
+      sync_subs_cam.push_back(image_sub1);
+    }
+    PRINT_INFO("subscribing to cam (stereo): %s", cam_topic0.c_str());
+    PRINT_INFO("subscribing to cam (stereo): %s", cam_topic1.c_str());
   } else {
     // Now we should add any non-stereo callbacks here
     for (int i = 0; i < _app->get_params().state_options.num_cameras; i++) {
-      // read in the topic
+      // Read in the camera topic
       std::string cam_topic;
       _node->declare_parameter<std::string>("topic_camera" + std::to_string(i), "/cam" + std::to_string(i) + "/image_raw");
       _node->get_parameter("topic_camera" + std::to_string(i), cam_topic);
       parser->parse_external("relative_config_imucam", "cam" + std::to_string(i), "rostopic", cam_topic);
-      // create subscriber
-      // auto sub = _node->create_subscription<sensor_msgs::msg::Image>(
-      //    cam_topic, rclcpp::SensorDataQoS(), std::bind(&ROS2Visualizer::callback_monocular, this, std::placeholders::_1, i));
-      auto sub = _node->create_subscription<sensor_msgs::msg::Image>(
-          cam_topic, 10, [this, i](const sensor_msgs::msg::Image::SharedPtr msg0) { callback_monocular(msg0, i); });
-      subs_cam.push_back(sub);
-      PRINT_INFO("subscribing to cam (mono): %s\n", cam_topic.c_str());
+
+      if (_app->get_params().use_dynamic_mask) {
+        // Use dynamic_mask_topic0 for cam0, dynamic_mask_topic1 for cam1
+        std::string mask_topic = (i == 0) ? _app->get_params().dynamic_mask_topic0 : _app->get_params().dynamic_mask_topic1;
+        PRINT_INFO("subscribing to mono mask for cam%d: %s", i, mask_topic.c_str());
+
+        auto image_sub = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(_node, cam_topic);
+        auto mask_sub = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(_node, mask_topic);
+
+        auto sync = std::make_shared<message_filters::Synchronizer<sync_pol_mono_mask>>(sync_pol_mono_mask(10), *image_sub, *mask_sub);
+        sync->registerCallback(std::bind(&ROS2Visualizer::callback_monocular_masks, this, std::placeholders::_1, std::placeholders::_2, i));
+
+        sync_cam_mono_masks.push_back(sync);
+        sync_subs_cam.push_back(image_sub);
+        sync_subs_cam.push_back(mask_sub);
+      } else {
+        // Original monocular logic
+        auto sub = _node->create_subscription<sensor_msgs::msg::Image>(
+            cam_topic, 10, [this, i](const sensor_msgs::msg::Image::SharedPtr msg0) { callback_monocular(msg0, i); });
+        subs_cam.push_back(sub);
+      }
+      PRINT_INFO("subscribing to cam (mono): %s", cam_topic.c_str());
     }
   }
 }
@@ -583,6 +619,147 @@ void ROS2Visualizer::callback_stereo(const sensor_msgs::msg::Image::ConstSharedP
   }
 
   // append it to our queue of images
+  std::lock_guard<std::mutex> lck(camera_queue_mtx);
+  camera_queue.push_back(message);
+  std::sort(camera_queue.begin(), camera_queue.end());
+}
+
+void ROS2Visualizer::callback_stereo_masks(const sensor_msgs::msg::Image::ConstSharedPtr msg0,
+                                           const sensor_msgs::msg::Image::ConstSharedPtr msg1,
+                                           const sensor_msgs::msg::Image::ConstSharedPtr mask0,
+                                           const sensor_msgs::msg::Image::ConstSharedPtr mask1, int cam_id0, int cam_id1) {
+
+  // Check if we should drop this image (throttling)
+  double timestamp = msg0->header.stamp.sec + msg0->header.stamp.nanosec * 1e-9;
+  double time_delta = 1.0 / _app->get_params().track_frequency;
+  if (camera_last_timestamp.find(cam_id0) != camera_last_timestamp.end() && timestamp < camera_last_timestamp.at(cam_id0) + time_delta) {
+    return;
+  }
+  camera_last_timestamp[cam_id0] = timestamp;
+
+  // Get the images
+  cv_bridge::CvImageConstPtr cv_ptr0, cv_ptr1, cv_mask0, cv_mask1;
+  try {
+    cv_ptr0 = cv_bridge::toCvShare(msg0, sensor_msgs::image_encodings::MONO8);
+    cv_ptr1 = cv_bridge::toCvShare(msg1, sensor_msgs::image_encodings::MONO8);
+    // Ensure masks are mono8
+    cv_mask0 = cv_bridge::toCvShare(mask0, sensor_msgs::image_encodings::MONO8);
+    cv_mask1 = cv_bridge::toCvShare(mask1, sensor_msgs::image_encodings::MONO8);
+  } catch (cv_bridge::Exception &e) {
+    PRINT_ERROR("cv_bridge exception: %s", e.what());
+    return;
+  }
+
+  // Create the measurement
+  ov_core::CameraData message;
+  message.timestamp = cv_ptr0->header.stamp.sec + cv_ptr0->header.stamp.nanosec * 1e-9;
+  message.sensor_ids.push_back(cam_id0);
+  message.sensor_ids.push_back(cam_id1);
+  message.images.push_back(cv_ptr0->image.clone());
+  message.images.push_back(cv_ptr1->image.clone());
+
+  // === MASK COMBINATION LOGIC ===
+  // 1. Get the dynamic masks from ROS message
+  cv::Mat dyn_mask0 = cv_mask0->image;
+  cv::Mat dyn_mask1 = cv_mask1->image;
+
+  // 2. Get the static masks if enabled (from config)
+  cv::Mat final_mask0, final_mask1;
+
+  if (_app->get_params().use_mask) {
+    // Merge Static + Dynamic for Cam 0
+    cv::Mat static_mask0 = _app->get_params().masks.at(cam_id0);
+    if (!dyn_mask0.empty() && !static_mask0.empty()) {
+      if (dyn_mask0.rows != static_mask0.rows || dyn_mask0.cols != static_mask0.cols) {
+        PRINT_WARNING(YELLOW "Dynamic mask size mismatch for Cam0! Resizing...\n" RESET);
+        cv::resize(dyn_mask0, dyn_mask0, static_mask0.size(), 0, 0, cv::INTER_NEAREST);
+      }
+      cv::bitwise_or(dyn_mask0, static_mask0, final_mask0);
+    } else {
+      final_mask0 = dyn_mask0.empty() ? static_mask0 : dyn_mask0;
+    }
+
+    // Merge Static + Dynamic for Cam 1
+    cv::Mat static_mask1 = _app->get_params().masks.at(cam_id1);
+    if (!dyn_mask1.empty() && !static_mask1.empty()) {
+      if (dyn_mask1.rows != static_mask0.rows || dyn_mask1.cols != static_mask0.cols) {
+        PRINT_WARNING(YELLOW "Dynamic mask size mismatch for Cam1! Resizing...\n" RESET);
+        cv::resize(dyn_mask1, dyn_mask1, static_mask0.size(), 0, 0, cv::INTER_NEAREST);
+      }
+      cv::bitwise_or(dyn_mask1, static_mask1, final_mask1);
+    } else {
+      final_mask1 = dyn_mask1.empty() ? static_mask1 : dyn_mask1;
+    }
+
+  } else {
+    // Only use dynamic masks
+    final_mask0 = dyn_mask0.clone();
+    final_mask1 = dyn_mask1.clone();
+  }
+
+  // 3. Ensure we have valid masks (black if empty)
+  if (final_mask0.empty())
+    final_mask0 = cv::Mat::zeros(cv_ptr0->image.rows, cv_ptr0->image.cols, CV_8UC1);
+  if (final_mask1.empty())
+    final_mask1 = cv::Mat::zeros(cv_ptr1->image.rows, cv_ptr1->image.cols, CV_8UC1);
+
+  message.masks.push_back(final_mask0);
+  message.masks.push_back(final_mask1);
+  // ==============================
+
+  // Append to our queue of images
+  std::lock_guard<std::mutex> lck(camera_queue_mtx);
+  camera_queue.push_back(message);
+  std::sort(camera_queue.begin(), camera_queue.end());
+}
+
+void ROS2Visualizer::callback_monocular_masks(const sensor_msgs::msg::Image::ConstSharedPtr msg,
+                                              const sensor_msgs::msg::Image::ConstSharedPtr mask, int cam_id) {
+  // Throttling logic
+  double timestamp = msg->header.stamp.sec + msg->header.stamp.nanosec * 1e-9;
+  double time_delta = 1.0 / _app->get_params().track_frequency;
+  if (camera_last_timestamp.find(cam_id) != camera_last_timestamp.end() && timestamp < camera_last_timestamp.at(cam_id) + time_delta) {
+    return;
+  }
+  camera_last_timestamp[cam_id] = timestamp;
+
+  // Get image and mask
+  cv_bridge::CvImageConstPtr cv_ptr, cv_mask;
+  try {
+    cv_ptr = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::MONO8);
+    cv_mask = cv_bridge::toCvShare(mask, sensor_msgs::image_encodings::MONO8);
+  } catch (cv_bridge::Exception &e) {
+    PRINT_ERROR("cv_bridge exception: %s", e.what());
+    return;
+  }
+
+  // Create measurement
+  ov_core::CameraData message;
+  message.timestamp = timestamp;
+  message.sensor_ids.push_back(cam_id);
+  message.images.push_back(cv_ptr->image.clone());
+
+  // Merge static and dynamic masks
+  cv::Mat final_mask;
+  cv::Mat dyn_mask = cv_mask->image;
+  if (_app->get_params().use_mask) {
+    cv::Mat static_mask = _app->get_params().masks.at(cam_id);
+    if (!dyn_mask.empty() && !static_mask.empty()) {
+      if (dyn_mask.rows != static_mask.rows || dyn_mask.cols != static_mask.cols) {
+        PRINT_WARNING(YELLOW "Dynamic mask size mismatch for Cam! Resizing...\n" RESET);
+        cv::resize(dyn_mask, dyn_mask, static_mask.size(), 0, 0, cv::INTER_NEAREST);
+      }
+      cv::bitwise_or(dyn_mask, static_mask, final_mask);
+    } else {
+      final_mask = dyn_mask.empty() ? static_mask : dyn_mask;
+    }
+  } else {
+    final_mask = dyn_mask.clone();
+  }
+  if (final_mask.empty())
+    final_mask = cv::Mat::zeros(cv_ptr->image.rows, cv_ptr->image.cols, CV_8UC1);
+  message.masks.push_back(final_mask);
+
   std::lock_guard<std::mutex> lck(camera_queue_mtx);
   camera_queue.push_back(message);
   std::sort(camera_queue.begin(), camera_queue.end());

--- a/ov_msckf/src/ros/ROS2Visualizer.h
+++ b/ov_msckf/src/ros/ROS2Visualizer.h
@@ -25,7 +25,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/time_synchronizer.h>
@@ -42,7 +42,7 @@
 #include <std_msgs/msg/float64.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/transform_datatypes.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 
 #include <atomic>
@@ -119,6 +119,11 @@ public:
   void callback_stereo(const sensor_msgs::msg::Image::ConstSharedPtr msg0, const sensor_msgs::msg::Image::ConstSharedPtr msg1, int cam_id0,
                        int cam_id1);
 
+  /// Callback for synchronized stereo camera information WITH dynamic masks
+  void callback_stereo_masks(const sensor_msgs::msg::Image::ConstSharedPtr msg0, const sensor_msgs::msg::Image::ConstSharedPtr msg1,
+                             const sensor_msgs::msg::Image::ConstSharedPtr mask0, const sensor_msgs::msg::Image::ConstSharedPtr mask1,
+                             int cam_id0, int cam_id1);
+
 protected:
   /// Publish the current state
   void publish_state();
@@ -159,8 +164,16 @@ protected:
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu;
   std::vector<rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr> subs_cam;
   typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::msg::Image, sensor_msgs::msg::Image> sync_pol;
+  typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::msg::Image, sensor_msgs::msg::Image, sensor_msgs::msg::Image,
+                                                          sensor_msgs::msg::Image>
+      sync_pol_masks;
+  typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::msg::Image, sensor_msgs::msg::Image> sync_pol_mono_mask;
   std::vector<std::shared_ptr<message_filters::Synchronizer<sync_pol>>> sync_cam;
   std::vector<std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>>> sync_subs_cam;
+  std::vector<std::shared_ptr<message_filters::Synchronizer<sync_pol_masks>>> sync_cam_masks;
+  std::vector<std::shared_ptr<message_filters::Synchronizer<sync_pol_mono_mask>>> sync_cam_mono_masks;
+  void callback_monocular_masks(const sensor_msgs::msg::Image::ConstSharedPtr msg, const sensor_msgs::msg::Image::ConstSharedPtr mask,
+                                int cam_id);
 
   // For path viz
   std::vector<geometry_msgs::msg::PoseStamped> poses_imu;

--- a/ov_msckf/src/ros/ROS2Visualizer.h
+++ b/ov_msckf/src/ros/ROS2Visualizer.h
@@ -149,6 +149,10 @@ protected:
   /// Simulator (is nullptr if we are not sim'ing)
   std::shared_ptr<Simulator> _sim;
 
+  /// ImageTransport instance kept alive for the lifetime of the visualizer.
+  /// Must outlive all image_transport::Publisher members below.
+  image_transport::ImageTransport _it;
+
   // Our publishers
   image_transport::Publisher it_pub_tracks, it_pub_loop_img_depth, it_pub_loop_img_depth_color;
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pub_poseimu;

--- a/ov_msckf/src/ros/ROSVisualizerHelper.h
+++ b/ov_msckf/src/ros/ROSVisualizerHelper.h
@@ -34,7 +34,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <tf2/transform_datatypes.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
 namespace ov_type {

--- a/ov_msckf/src/update/UpdaterMSCKF.cpp
+++ b/ov_msckf/src/update/UpdaterMSCKF.cpp
@@ -21,7 +21,10 @@
 
 #include "UpdaterMSCKF.h"
 
+#include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <numeric>
 #include <unordered_map>
 
 #include "UpdaterHelper.h"
@@ -223,6 +226,7 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
       const auto &times0 = feat.timestamps.at(0);
       const auto &norms0 = feat.uvs_norm.at(0);
       if (times0.size() >= 2) {
+        auto _nm_t0 = std::chrono::high_resolution_clock::now();
         cv::Matx33d K0 = state->_cam_intrinsics_cameras.at(0)->get_K();
         double fx = K0(0, 0);
         Eigen::Matrix3d R_ItoC0 = state->_calib_IMUtoCAM.at(0)->Rot();
@@ -330,6 +334,30 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
             }
           }
         } // tri_gate_ok
+
+        // One-shot timing report: accumulate first 10 000 nm evaluations, then print once.
+        // Disabled when use_imu_residual=false (this block is never entered).
+        static std::vector<double> _nm_timings;
+        static bool _nm_timing_done = false;
+        if (!_nm_timing_done) {
+          double _nm_us = std::chrono::duration<double, std::micro>(
+              std::chrono::high_resolution_clock::now() - _nm_t0).count();
+          _nm_timings.push_back(_nm_us);
+          if (_nm_timings.size() >= 10000) {
+            _nm_timing_done = true;
+            std::sort(_nm_timings.begin(), _nm_timings.end());
+            double mean_us = std::accumulate(_nm_timings.begin(), _nm_timings.end(), 0.0)
+                             / static_cast<double>(_nm_timings.size());
+            double med_us  = _nm_timings[_nm_timings.size() / 2];
+            double p95_us  = _nm_timings[static_cast<size_t>(_nm_timings.size() * 0.95)];
+            PRINT_INFO("[SoftGate-nm timing] N=%zu  mean=%.2f µs  median=%.2f µs  p95=%.2f µs"
+                       "  =>  +%.2f ms/update at 600 features\n",
+                       _nm_timings.size(), mean_us, med_us, p95_us,
+                       mean_us * 600.0 / 1000.0);
+            _nm_timings.clear();
+            _nm_timings.shrink_to_fit();
+          }
+        }
       }
     }
 

--- a/ov_msckf/src/update/UpdaterMSCKF.cpp
+++ b/ov_msckf/src/update/UpdaterMSCKF.cpp
@@ -21,6 +21,9 @@
 
 #include "UpdaterMSCKF.h"
 
+#include <cmath>
+#include <unordered_map>
+
 #include "UpdaterHelper.h"
 
 #include "feat/Feature.h"
@@ -33,7 +36,9 @@
 #include "utils/quat_ops.h"
 
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/math/distributions/chi_squared.hpp>
+#include <iomanip>
 
 using namespace ov_core;
 using namespace ov_type;
@@ -52,6 +57,23 @@ UpdaterMSCKF::UpdaterMSCKF(UpdaterOptions &options, ov_core::FeatureInitializerO
   for (int i = 1; i < 500; i++) {
     boost::math::chi_squared chi_squared_dist(i);
     chi_squared_table[i] = boost::math::quantile(chi_squared_dist, 0.95);
+  }
+}
+
+void UpdaterMSCKF::set_feature_logger_params(bool enable, const std::string &path) {
+  _log_features = enable;
+  if (!enable || path.empty())
+    return;
+  boost::filesystem::path p(path);
+  boost::filesystem::create_directories(p.parent_path());
+  _feat_log_file.open(path, std::ofstream::out | std::ofstream::trunc);
+  if (_feat_log_file.is_open()) {
+    _feat_log_file << "# ts,feat_id,u_act,v_act,u_pred,v_pred,nm,r_px,depth,"
+                      "track_len,t_prev,u_prev,v_prev,dangle_x,dangle_y,dangle_z,dt\n";
+    PRINT_INFO(GREEN "[FEAT_LOG]: opened feature log at %s\n" RESET, path.c_str());
+  } else {
+    PRINT_WARNING(YELLOW "[FEAT_LOG]: failed to open feature log at %s\n" RESET, path.c_str());
+    _log_features = false;
   }
 }
 
@@ -205,10 +227,103 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
     // Nullspace project
     UpdaterHelper::nullspace_project_inplace(H_f, H_x, res);
 
-    /// Chi2 distance check
+    // Option C: per-feature nm using triangulated p_FinG (accurate depth, not raw disparity).
+    // Project p_FinG into cam0 at t_new using IMU-propagated pose; compare to actual observation.
+    // Dead-zone of 3*sigma_pix prevents noise-level residuals from inflating static features.
+    // Also runs when _log_features is true (even if _use_imu_residual is false) so that the
+    // dataset builder gets u_pred/v_pred for target patch extraction.
+    double nm = 1.0;
+    if ((_use_imu_residual || _log_features) &&
+        !LandmarkRepresentation::is_relative_representation(feat.feat_representation) &&
+        feat.p_FinG.norm() > 0.01 &&
+        state->_cam_intrinsics_cameras.count(0) && state->_calib_IMUtoCAM.count(0) &&
+        feat.timestamps.count(0) && feat.uvs_norm.count(0)) {
+      const auto &times0 = feat.timestamps.at(0);
+      const auto &norms0 = feat.uvs_norm.at(0);
+      if (times0.size() >= 2) {
+        double t_new = times0.back();
+        if (state->_clones_IMU.count(t_new)) {
+          cv::Matx33d K0 = state->_cam_intrinsics_cameras.at(0)->get_K();
+          double fx = K0(0, 0);
+          double fy = K0(1, 1);
+          double cx = K0(0, 2);
+          double cy = K0(1, 2);
+          Eigen::Matrix3d R_ItoC0 = state->_calib_IMUtoCAM.at(0)->Rot();
+          Eigen::Vector3d p_C0inI = state->_calib_IMUtoCAM.at(0)->pos();
+          Eigen::Matrix3d R_GtoI_new = state->_clones_IMU.at(t_new)->Rot();
+          Eigen::Vector3d p_IinG_new = state->_clones_IMU.at(t_new)->pos();
+          Eigen::Matrix3d R_GtoC0_new = R_ItoC0 * R_GtoI_new;
+          Eigen::Vector3d p_C0inG_new = p_IinG_new - R_GtoC0_new.transpose() * p_C0inI;
+          Eigen::Vector3d X_Ct = R_GtoC0_new * (feat.p_FinG - p_C0inG_new);
+          if (X_Ct[2] > 0.1) {
+            double n_pred_x = X_Ct[0] / X_Ct[2];
+            double n_pred_y = X_Ct[1] / X_Ct[2];
+            double n_act_x = norms0.back()[0];
+            double n_act_y = norms0.back()[1];
+            double r_px = fx * std::sqrt(std::pow(n_pred_x - n_act_x, 2) + std::pow(n_pred_y - n_act_y, 2));
+
+            // Always compute the geometric inconsistency score (nm_score) so the
+            // feature log gets meaningful values even when _use_imu_residual is false.
+            // nm_score uses the same formula as the Phase 1 noise inflation but is
+            // computed purely for logging — it does NOT affect the VIO covariance.
+            double noise_floor = 3.0 * _options.sigma_pix;
+            double effective_r = std::max(0.0, r_px - noise_floor);
+            double s_imu = std::exp(-effective_r / _imu_residual_sigma_px);
+            double nm_score = std::max(1.0, 1.0 + _imu_residual_alpha * (1.0 - s_imu));
+
+            if (_use_imu_residual) {
+              // Apply noise inflation to the VIO update only when enabled.
+              nm = nm_score;
+            }
+
+            // Feature logger for JEPA dataset construction (Phase 2).
+            // Writes one row per feature: actual pixel, IMU-predicted pixel, nm_score,
+            // depth, previous-frame pixel, and IMU rotation delta (predictor conditioning).
+            if (_log_features && _feat_log_file.is_open()) {
+              double u_act  = fx * n_act_x  + cx;
+              double v_act  = fy * n_act_y  + cy;
+              double u_pred = fx * n_pred_x + cx;
+              double v_pred = fy * n_pred_y + cy;
+
+              // Previous observation (t-1) for context patch and IMU delta
+              double t_prev = -1.0, u_prev = 0.0, v_prev = 0.0;
+              double dangle_x = 0.0, dangle_y = 0.0, dangle_z = 0.0, dt = 0.0;
+              if (times0.size() >= 2) {
+                t_prev = times0[times0.size() - 2];
+                const auto &n_prev = norms0[norms0.size() - 2];
+                u_prev = fx * (double)n_prev[0] + cx;
+                v_prev = fy * (double)n_prev[1] + cy;
+                dt = t_new - t_prev;
+                if (state->_clones_IMU.count(t_prev)) {
+                  // Relative rotation from t_prev to t_new in IMU frame → axis-angle
+                  Eigen::Matrix3d R_GtoI_prev = state->_clones_IMU.at(t_prev)->Rot();
+                  Eigen::Matrix3d R_rel = R_GtoI_prev.transpose() * R_GtoI_new;
+                  Eigen::AngleAxisd aa(R_rel);
+                  Eigen::Vector3d av = aa.angle() * aa.axis();
+                  dangle_x = av[0]; dangle_y = av[1]; dangle_z = av[2];
+                }
+              }
+
+              _feat_log_file << std::fixed << std::setprecision(9)
+                << t_new     << "," << feat.featid << ","
+                << u_act     << "," << v_act       << ","
+                << u_pred    << "," << v_pred       << ","
+                << nm_score  << "," << r_px         << "," << X_Ct[2] << ","
+                << (int)times0.size() << ","
+                << t_prev    << "," << u_prev << "," << v_prev << ","
+                << dangle_x  << "," << dangle_y << "," << dangle_z << "," << dt << "\n";
+            }
+          }
+        }
+      }
+    }
+
+    // Chi2 distance check — use inflated noise nm*sigma_pix_sq as expected model.
+    // Dynamic features are gated at their actual expected noise level, not the
+    // static baseline (prevents hard-rejection of slow-moving dynamic features).
     Eigen::MatrixXd P_marg = StateHelper::get_marginal_covariance(state, Hx_order);
     Eigen::MatrixXd S = H_x * P_marg * H_x.transpose();
-    S.diagonal() += _options.sigma_pix_sq * Eigen::VectorXd::Ones(S.rows());
+    S.diagonal() += (nm * _options.sigma_pix_sq) * Eigen::VectorXd::Ones(S.rows());
     double chi2 = res.dot(S.llt().solve(res));
 
     // Get our threshold (we precompute up to 500 but handle the case that it is more)
@@ -225,12 +340,17 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
     if (chi2 > _options.chi2_multipler * chi2_check) {
       (*it2)->to_delete = true;
       it2 = feature_vec.erase(it2);
-      // PRINT_DEBUG("featid = %d\n", feat.featid);
-      // PRINT_DEBUG("chi2 = %f > %f\n", chi2, _options.chi2_multipler*chi2_check);
-      // std::stringstream ss;
-      // ss << "res = " << std::endl << res.transpose() << std::endl;
-      // PRINT_DEBUG(ss.str().c_str());
       continue;
+    }
+
+    // Measurement whitening for per-feature noise: divide H_x and res by sqrt(nm).
+    // After this scaling the global R_big = sigma_pix_sq*I is the correct noise model,
+    // equivalent to nm*sigma_pix_sq per feature in the Kalman update.
+    // Dynamic features (nm >> 1) are down-weighted; static features (nm = 1.0) unchanged.
+    if (nm > 1.0) {
+      double inv_sqrt_nm = 1.0 / std::sqrt(nm);
+      H_x *= inv_sqrt_nm;
+      res *= inv_sqrt_nm;
     }
 
     // We are good!!! Append to our large H vector

--- a/ov_msckf/src/update/UpdaterMSCKF.cpp
+++ b/ov_msckf/src/update/UpdaterMSCKF.cpp
@@ -36,9 +36,7 @@
 #include "utils/quat_ops.h"
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/math/distributions/chi_squared.hpp>
-#include <iomanip>
 
 using namespace ov_core;
 using namespace ov_type;
@@ -57,23 +55,6 @@ UpdaterMSCKF::UpdaterMSCKF(UpdaterOptions &options, ov_core::FeatureInitializerO
   for (int i = 1; i < 500; i++) {
     boost::math::chi_squared chi_squared_dist(i);
     chi_squared_table[i] = boost::math::quantile(chi_squared_dist, 0.95);
-  }
-}
-
-void UpdaterMSCKF::set_feature_logger_params(bool enable, const std::string &path) {
-  _log_features = enable;
-  if (!enable || path.empty())
-    return;
-  boost::filesystem::path p(path);
-  boost::filesystem::create_directories(p.parent_path());
-  _feat_log_file.open(path, std::ofstream::out | std::ofstream::trunc);
-  if (_feat_log_file.is_open()) {
-    _feat_log_file << "# ts,feat_id,u_act,v_act,u_pred,v_pred,nm,r_px,depth,"
-                      "track_len,t_prev,u_prev,v_prev,dangle_x,dangle_y,dangle_z,dt\n";
-    PRINT_INFO(GREEN "[FEAT_LOG]: opened feature log at %s\n" RESET, path.c_str());
-  } else {
-    PRINT_WARNING(YELLOW "[FEAT_LOG]: failed to open feature log at %s\n" RESET, path.c_str());
-    _log_features = false;
   }
 }
 
@@ -230,10 +211,8 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
     // Option C: per-feature nm using triangulated p_FinG (accurate depth, not raw disparity).
     // Project p_FinG into cam0 at t_new using IMU-propagated pose; compare to actual observation.
     // Dead-zone of 3*sigma_pix prevents noise-level residuals from inflating static features.
-    // Also runs when _log_features is true (even if _use_imu_residual is false) so that the
-    // dataset builder gets u_pred/v_pred for target patch extraction.
     double nm = 1.0;
-    if ((_use_imu_residual || _log_features) &&
+    if (_use_imu_residual &&
         !LandmarkRepresentation::is_relative_representation(feat.feat_representation) &&
         feat.p_FinG.norm() > 0.01 &&
         state->_cam_intrinsics_cameras.count(0) && state->_calib_IMUtoCAM.count(0) &&
@@ -241,15 +220,52 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
       const auto &times0 = feat.timestamps.at(0);
       const auto &norms0 = feat.uvs_norm.at(0);
       if (times0.size() >= 2) {
+        cv::Matx33d K0 = state->_cam_intrinsics_cameras.at(0)->get_K();
+        double fx = K0(0, 0);
+        Eigen::Matrix3d R_ItoC0 = state->_calib_IMUtoCAM.at(0)->Rot();
+        Eigen::Vector3d p_C0inI = state->_calib_IMUtoCAM.at(0)->pos();
+
+        // Variance mode: std-dev of per-clone reprojection residuals.
+        // Triangulation error adds a constant bias c to every r_k → cancels in variance.
+        // A static feature has low std_r (consistent bias); a dynamic feature has high
+        // std_r (true position changes, p_FinG stays fixed → different residual each clone).
+        // Requires ≥3 valid clones; falls back to nm=1 for short tracks.
+        if (_use_imu_residual && _use_residual_variance) {
+          double sum_r = 0.0, sum_r2 = 0.0;
+          int n_var = 0;
+          for (size_t k = 0; k < times0.size(); k++) {
+            double t_k = times0[k];
+            if (!state->_clones_IMU.count(t_k))
+              continue;
+            Eigen::Matrix3d R_GtoI_k = state->_clones_IMU.at(t_k)->Rot();
+            Eigen::Vector3d p_IinG_k = state->_clones_IMU.at(t_k)->pos();
+            Eigen::Matrix3d R_GtoC0_k = R_ItoC0 * R_GtoI_k;
+            Eigen::Vector3d p_C0inG_k = p_IinG_k - R_GtoC0_k.transpose() * p_C0inI;
+            Eigen::Vector3d X_k       = R_GtoC0_k * (feat.p_FinG - p_C0inG_k);
+            if (X_k[2] <= 0.1)
+              continue;
+            double n_px = X_k[0] / X_k[2];
+            double n_py = X_k[1] / X_k[2];
+            double n_ax = static_cast<double>(norms0[k][0]);
+            double n_ay = static_cast<double>(norms0[k][1]);
+            double r_k  = fx * std::sqrt(std::pow(n_px - n_ax, 2) + std::pow(n_py - n_ay, 2));
+            sum_r  += r_k;
+            sum_r2 += r_k * r_k;
+            n_var++;
+          }
+          if (n_var >= 3) {
+            double mean_r = sum_r / n_var;
+            double var_r  = std::max(0.0, sum_r2 / n_var - mean_r * mean_r);
+            double std_r  = std::sqrt(var_r);
+            double s      = std::exp(-std_r / _imu_residual_sigma_px);
+            nm = std::max(1.0, 1.0 + _imu_residual_alpha * (1.0 - s));
+          }
+          // n_var < 3: nm stays 1.0 (too few observations, trust the feature)
+        }
+
+        // Single-frame residual at newest clone.
         double t_new = times0.back();
         if (state->_clones_IMU.count(t_new)) {
-          cv::Matx33d K0 = state->_cam_intrinsics_cameras.at(0)->get_K();
-          double fx = K0(0, 0);
-          double fy = K0(1, 1);
-          double cx = K0(0, 2);
-          double cy = K0(1, 2);
-          Eigen::Matrix3d R_ItoC0 = state->_calib_IMUtoCAM.at(0)->Rot();
-          Eigen::Vector3d p_C0inI = state->_calib_IMUtoCAM.at(0)->pos();
           Eigen::Matrix3d R_GtoI_new = state->_clones_IMU.at(t_new)->Rot();
           Eigen::Vector3d p_IinG_new = state->_clones_IMU.at(t_new)->pos();
           Eigen::Matrix3d R_GtoC0_new = R_ItoC0 * R_GtoI_new;
@@ -262,56 +278,18 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
             double n_act_y = norms0.back()[1];
             double r_px = fx * std::sqrt(std::pow(n_pred_x - n_act_x, 2) + std::pow(n_pred_y - n_act_y, 2));
 
-            // Always compute the geometric inconsistency score (nm_score) so the
-            // feature log gets meaningful values even when _use_imu_residual is false.
-            // nm_score uses the same formula as the Phase 1 noise inflation but is
-            // computed purely for logging — it does NOT affect the VIO covariance.
-            double noise_floor = 3.0 * _options.sigma_pix;
-            double effective_r = std::max(0.0, r_px - noise_floor);
-            double s_imu = std::exp(-effective_r / _imu_residual_sigma_px);
-            double nm_score = std::max(1.0, 1.0 + _imu_residual_alpha * (1.0 - s_imu));
-
-            if (_use_imu_residual) {
-              // Apply noise inflation to the VIO update only when enabled.
-              nm = nm_score;
+            if (!_use_residual_variance) {
+              double noise_floor = 3.0 * _options.sigma_pix;
+              double effective_r = std::max(0.0, r_px - noise_floor);
+              double s_imu = std::exp(-effective_r / _imu_residual_sigma_px);
+              nm = std::max(1.0, 1.0 + _imu_residual_alpha * (1.0 - s_imu));
             }
 
-            // Feature logger for JEPA dataset construction (Phase 2).
-            // Writes one row per feature: actual pixel, IMU-predicted pixel, nm_score,
-            // depth, previous-frame pixel, and IMU rotation delta (predictor conditioning).
-            if (_log_features && _feat_log_file.is_open()) {
-              double u_act  = fx * n_act_x  + cx;
-              double v_act  = fy * n_act_y  + cy;
-              double u_pred = fx * n_pred_x + cx;
-              double v_pred = fy * n_pred_y + cy;
-
-              // Previous observation (t-1) for context patch and IMU delta
-              double t_prev = -1.0, u_prev = 0.0, v_prev = 0.0;
-              double dangle_x = 0.0, dangle_y = 0.0, dangle_z = 0.0, dt = 0.0;
-              if (times0.size() >= 2) {
-                t_prev = times0[times0.size() - 2];
-                const auto &n_prev = norms0[norms0.size() - 2];
-                u_prev = fx * (double)n_prev[0] + cx;
-                v_prev = fy * (double)n_prev[1] + cy;
-                dt = t_new - t_prev;
-                if (state->_clones_IMU.count(t_prev)) {
-                  // Relative rotation from t_prev to t_new in IMU frame → axis-angle
-                  Eigen::Matrix3d R_GtoI_prev = state->_clones_IMU.at(t_prev)->Rot();
-                  Eigen::Matrix3d R_rel = R_GtoI_prev.transpose() * R_GtoI_new;
-                  Eigen::AngleAxisd aa(R_rel);
-                  Eigen::Vector3d av = aa.angle() * aa.axis();
-                  dangle_x = av[0]; dangle_y = av[1]; dangle_z = av[2];
-                }
-              }
-
-              _feat_log_file << std::fixed << std::setprecision(9)
-                << t_new     << "," << feat.featid << ","
-                << u_act     << "," << v_act       << ","
-                << u_pred    << "," << v_pred       << ","
-                << nm_score  << "," << r_px         << "," << X_Ct[2] << ","
-                << (int)times0.size() << ","
-                << t_prev    << "," << u_prev << "," << v_prev << ","
-                << dangle_x  << "," << dangle_y << "," << dangle_z << "," << dt << "\n";
+            // Depth gate: features beyond max_depth have low stereo disparity and
+            // unreliable p_FinG → suppress nm to avoid false inflation.
+            // Applies to both single-frame and variance modes (X_Ct is from newest clone).
+            if (nm > 1.0 && _imu_residual_max_depth > 0.0 && X_Ct[2] > _imu_residual_max_depth) {
+              nm = 1.0;
             }
           }
         }

--- a/ov_msckf/src/update/UpdaterMSCKF.cpp
+++ b/ov_msckf/src/update/UpdaterMSCKF.cpp
@@ -217,8 +217,15 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
     //   SoftGate nm:   IMU reprojection residual → continuous nm inflation  (use_imu_residual)
     //   Depth gate:    suppress nm for far features with unreliable stereo   (imu_residual_max_depth)
     //   Tri gate:      suppress nm when triangulation itself is poor          (imu_residual_max_tri_error)
+    // Post-init delay: suppress nm while IMU biases are still converging.
+    // _nm_start_time is set on the first feature processed after init.
+    if (_imu_residual_init_delay > 0.0 && _nm_start_time < 0.0)
+      _nm_start_time = state->_timestamp;
+
     double nm = 1.0;
-    if (_use_imu_residual &&
+    const bool _nm_active = (_imu_residual_init_delay <= 0.0) ||
+                            (state->_timestamp - _nm_start_time >= _imu_residual_init_delay);
+    if (_nm_active && _use_imu_residual &&
         !LandmarkRepresentation::is_relative_representation(feat.feat_representation) &&
         feat.p_FinG.norm() > 0.01 &&
         state->_cam_intrinsics_cameras.count(0) && state->_calib_IMUtoCAM.count(0) &&

--- a/ov_msckf/src/update/UpdaterMSCKF.cpp
+++ b/ov_msckf/src/update/UpdaterMSCKF.cpp
@@ -315,7 +315,7 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
               double r_px     = fx * std::sqrt(std::pow(n_pred_x - n_act_x, 2) + std::pow(n_pred_y - n_act_y, 2));
 
               if (!_use_residual_variance) {
-                double noise_floor = 3.0 * _options.sigma_pix;
+                double noise_floor = _imu_residual_dead_zone * _options.sigma_pix;
                 double effective_r = std::max(0.0, r_px - noise_floor);
                 double s_imu       = std::exp(-effective_r / _imu_residual_sigma_px);
                 nm = std::max(1.0, 1.0 + _imu_residual_alpha * (1.0 - s_imu));

--- a/ov_msckf/src/update/UpdaterMSCKF.cpp
+++ b/ov_msckf/src/update/UpdaterMSCKF.cpp
@@ -208,9 +208,12 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
     // Nullspace project
     UpdaterHelper::nullspace_project_inplace(H_f, H_x, res);
 
-    // Option C: per-feature nm using triangulated p_FinG (accurate depth, not raw disparity).
-    // Project p_FinG into cam0 at t_new using IMU-propagated pose; compare to actual observation.
-    // Dead-zone of 3*sigma_pix prevents noise-level residuals from inflating static features.
+    // Per-feature noise multiplier nm using triangulated p_FinG.
+    // Dynamic features receive nm > 1 → down-weighted in the EKF update, not hard-rejected.
+    // Three modular gates, each independently enabled via YAML (default: all disabled):
+    //   SoftGate nm:   IMU reprojection residual → continuous nm inflation  (use_imu_residual)
+    //   Depth gate:    suppress nm for far features with unreliable stereo   (imu_residual_max_depth)
+    //   Tri gate:      suppress nm when triangulation itself is poor          (imu_residual_max_tri_error)
     double nm = 1.0;
     if (_use_imu_residual &&
         !LandmarkRepresentation::is_relative_representation(feat.feat_representation) &&
@@ -225,20 +228,21 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
         Eigen::Matrix3d R_ItoC0 = state->_calib_IMUtoCAM.at(0)->Rot();
         Eigen::Vector3d p_C0inI = state->_calib_IMUtoCAM.at(0)->pos();
 
-        // Variance mode: std-dev of per-clone reprojection residuals.
-        // Triangulation error adds a constant bias c to every r_k → cancels in variance.
-        // A static feature has low std_r (consistent bias); a dynamic feature has high
-        // std_r (true position changes, p_FinG stays fixed → different residual each clone).
-        // Requires ≥3 valid clones; falls back to nm=1 for short tracks.
-        if (_use_imu_residual && _use_residual_variance) {
-          double sum_r = 0.0, sum_r2 = 0.0;
-          int n_var = 0;
+        // Triangulation quality gate.
+        // Computes RMS reprojection error of p_FinG across all window clones.
+        // High RMS means the triangulated position is unreliable (low-texture or
+        // degenerate geometry) → nm inflation would punish good features, not bad ones.
+        // Falls through (tri_gate_ok = true) when imu_residual_max_tri_error = 0 (default).
+        bool tri_gate_ok = true;
+        if (_imu_residual_max_tri_error > 0.0) {
+          double sum_r2_tri = 0.0;
+          int n_tri = 0;
           for (size_t k = 0; k < times0.size(); k++) {
             double t_k = times0[k];
             if (!state->_clones_IMU.count(t_k))
               continue;
-            Eigen::Matrix3d R_GtoI_k = state->_clones_IMU.at(t_k)->Rot();
-            Eigen::Vector3d p_IinG_k = state->_clones_IMU.at(t_k)->pos();
+            Eigen::Matrix3d R_GtoI_k  = state->_clones_IMU.at(t_k)->Rot();
+            Eigen::Vector3d p_IinG_k  = state->_clones_IMU.at(t_k)->pos();
             Eigen::Matrix3d R_GtoC0_k = R_ItoC0 * R_GtoI_k;
             Eigen::Vector3d p_C0inG_k = p_IinG_k - R_GtoC0_k.transpose() * p_C0inI;
             Eigen::Vector3d X_k       = R_GtoC0_k * (feat.p_FinG - p_C0inG_k);
@@ -249,50 +253,83 @@ void UpdaterMSCKF::update(std::shared_ptr<State> state, std::vector<std::shared_
             double n_ax = static_cast<double>(norms0[k][0]);
             double n_ay = static_cast<double>(norms0[k][1]);
             double r_k  = fx * std::sqrt(std::pow(n_px - n_ax, 2) + std::pow(n_py - n_ay, 2));
-            sum_r  += r_k;
-            sum_r2 += r_k * r_k;
-            n_var++;
+            sum_r2_tri += r_k * r_k;
+            n_tri++;
           }
-          if (n_var >= 3) {
-            double mean_r = sum_r / n_var;
-            double var_r  = std::max(0.0, sum_r2 / n_var - mean_r * mean_r);
-            double std_r  = std::sqrt(var_r);
-            double s      = std::exp(-std_r / _imu_residual_sigma_px);
-            nm = std::max(1.0, 1.0 + _imu_residual_alpha * (1.0 - s));
-          }
-          // n_var < 3: nm stays 1.0 (too few observations, trust the feature)
+          if (n_tri >= 2 && std::sqrt(sum_r2_tri / n_tri) > _imu_residual_max_tri_error)
+            tri_gate_ok = false;
         }
 
-        // Single-frame residual at newest clone.
-        double t_new = times0.back();
-        if (state->_clones_IMU.count(t_new)) {
-          Eigen::Matrix3d R_GtoI_new = state->_clones_IMU.at(t_new)->Rot();
-          Eigen::Vector3d p_IinG_new = state->_clones_IMU.at(t_new)->pos();
-          Eigen::Matrix3d R_GtoC0_new = R_ItoC0 * R_GtoI_new;
-          Eigen::Vector3d p_C0inG_new = p_IinG_new - R_GtoC0_new.transpose() * p_C0inI;
-          Eigen::Vector3d X_Ct = R_GtoC0_new * (feat.p_FinG - p_C0inG_new);
-          if (X_Ct[2] > 0.1) {
-            double n_pred_x = X_Ct[0] / X_Ct[2];
-            double n_pred_y = X_Ct[1] / X_Ct[2];
-            double n_act_x = norms0.back()[0];
-            double n_act_y = norms0.back()[1];
-            double r_px = fx * std::sqrt(std::pow(n_pred_x - n_act_x, 2) + std::pow(n_pred_y - n_act_y, 2));
-
-            if (!_use_residual_variance) {
-              double noise_floor = 3.0 * _options.sigma_pix;
-              double effective_r = std::max(0.0, r_px - noise_floor);
-              double s_imu = std::exp(-effective_r / _imu_residual_sigma_px);
-              nm = std::max(1.0, 1.0 + _imu_residual_alpha * (1.0 - s_imu));
+        if (tri_gate_ok) {
+          // Variance mode: std-dev of per-clone reprojection residuals.
+          // Triangulation error adds a constant bias c to every r_k → cancels in variance.
+          // A static feature has low std_r (consistent bias); a dynamic feature has high
+          // std_r (true position changes, p_FinG stays fixed → different residual each clone).
+          // Requires ≥3 valid clones; falls back to nm=1 for short tracks.
+          if (_use_imu_residual && _use_residual_variance) {
+            double sum_r = 0.0, sum_r2 = 0.0;
+            int n_var = 0;
+            for (size_t k = 0; k < times0.size(); k++) {
+              double t_k = times0[k];
+              if (!state->_clones_IMU.count(t_k))
+                continue;
+              Eigen::Matrix3d R_GtoI_k  = state->_clones_IMU.at(t_k)->Rot();
+              Eigen::Vector3d p_IinG_k  = state->_clones_IMU.at(t_k)->pos();
+              Eigen::Matrix3d R_GtoC0_k = R_ItoC0 * R_GtoI_k;
+              Eigen::Vector3d p_C0inG_k = p_IinG_k - R_GtoC0_k.transpose() * p_C0inI;
+              Eigen::Vector3d X_k       = R_GtoC0_k * (feat.p_FinG - p_C0inG_k);
+              if (X_k[2] <= 0.1)
+                continue;
+              double n_px = X_k[0] / X_k[2];
+              double n_py = X_k[1] / X_k[2];
+              double n_ax = static_cast<double>(norms0[k][0]);
+              double n_ay = static_cast<double>(norms0[k][1]);
+              double r_k  = fx * std::sqrt(std::pow(n_px - n_ax, 2) + std::pow(n_py - n_ay, 2));
+              sum_r  += r_k;
+              sum_r2 += r_k * r_k;
+              n_var++;
             }
+            if (n_var >= 3) {
+              double mean_r = sum_r / n_var;
+              double var_r  = std::max(0.0, sum_r2 / n_var - mean_r * mean_r);
+              double std_r  = std::sqrt(var_r);
+              double s      = std::exp(-std_r / _imu_residual_sigma_px);
+              nm = std::max(1.0, 1.0 + _imu_residual_alpha * (1.0 - s));
+            }
+            // n_var < 3: nm stays 1.0 (too few observations, trust the feature)
+          }
 
-            // Depth gate: features beyond max_depth have low stereo disparity and
-            // unreliable p_FinG → suppress nm to avoid false inflation.
-            // Applies to both single-frame and variance modes (X_Ct is from newest clone).
-            if (nm > 1.0 && _imu_residual_max_depth > 0.0 && X_Ct[2] > _imu_residual_max_depth) {
-              nm = 1.0;
+          // Single-frame residual at newest clone.
+          double t_new = times0.back();
+          if (state->_clones_IMU.count(t_new)) {
+            Eigen::Matrix3d R_GtoI_new  = state->_clones_IMU.at(t_new)->Rot();
+            Eigen::Vector3d p_IinG_new  = state->_clones_IMU.at(t_new)->pos();
+            Eigen::Matrix3d R_GtoC0_new = R_ItoC0 * R_GtoI_new;
+            Eigen::Vector3d p_C0inG_new = p_IinG_new - R_GtoC0_new.transpose() * p_C0inI;
+            Eigen::Vector3d X_Ct        = R_GtoC0_new * (feat.p_FinG - p_C0inG_new);
+            if (X_Ct[2] > 0.1) {
+              double n_pred_x = X_Ct[0] / X_Ct[2];
+              double n_pred_y = X_Ct[1] / X_Ct[2];
+              double n_act_x  = norms0.back()[0];
+              double n_act_y  = norms0.back()[1];
+              double r_px     = fx * std::sqrt(std::pow(n_pred_x - n_act_x, 2) + std::pow(n_pred_y - n_act_y, 2));
+
+              if (!_use_residual_variance) {
+                double noise_floor = 3.0 * _options.sigma_pix;
+                double effective_r = std::max(0.0, r_px - noise_floor);
+                double s_imu       = std::exp(-effective_r / _imu_residual_sigma_px);
+                nm = std::max(1.0, 1.0 + _imu_residual_alpha * (1.0 - s_imu));
+              }
+
+              // Depth gate: features beyond max_depth have low stereo disparity and
+              // unreliable p_FinG → suppress nm to avoid false inflation.
+              // Applies to both single-frame and variance modes (X_Ct is from newest clone).
+              if (nm > 1.0 && _imu_residual_max_depth > 0.0 && X_Ct[2] > _imu_residual_max_depth) {
+                nm = 1.0;
+              }
             }
           }
-        }
+        } // tri_gate_ok
       }
     }
 

--- a/ov_msckf/src/update/UpdaterMSCKF.h
+++ b/ov_msckf/src/update/UpdaterMSCKF.h
@@ -95,13 +95,14 @@ public:
    */
   void set_imu_residual_params(bool use, double alpha, double sigma_px,
                                bool use_variance = false, double max_depth = 0.0,
-                               double max_tri_error = 0.0) {
+                               double max_tri_error = 0.0, double dead_zone = 3.0) {
     _use_imu_residual = use;
     _imu_residual_alpha = alpha;
     _imu_residual_sigma_px = sigma_px;
     _use_residual_variance = use_variance;
     _imu_residual_max_depth = max_depth;
     _imu_residual_max_tri_error = max_tri_error;
+    _imu_residual_dead_zone = dead_zone;
   }
 
 protected:
@@ -121,6 +122,7 @@ protected:
   bool _use_residual_variance = false;        // use cross-clone residual std-dev instead of single-frame
   double _imu_residual_max_depth = 0.0;      // depth gate in metres (0 = disabled)
   double _imu_residual_max_tri_error = 0.0;  // triangulation quality gate: RMS reprojection px (0 = disabled)
+  double _imu_residual_dead_zone = 3.0;      // dead-zone multiplier: noise_floor = dead_zone * sigma_pix
 
 };
 

--- a/ov_msckf/src/update/UpdaterMSCKF.h
+++ b/ov_msckf/src/update/UpdaterMSCKF.h
@@ -95,7 +95,8 @@ public:
    */
   void set_imu_residual_params(bool use, double alpha, double sigma_px,
                                bool use_variance = false, double max_depth = 0.0,
-                               double max_tri_error = 0.0, double dead_zone = 3.0) {
+                               double max_tri_error = 0.0, double dead_zone = 3.0,
+                               double init_delay = 0.0) {
     _use_imu_residual = use;
     _imu_residual_alpha = alpha;
     _imu_residual_sigma_px = sigma_px;
@@ -103,6 +104,8 @@ public:
     _imu_residual_max_depth = max_depth;
     _imu_residual_max_tri_error = max_tri_error;
     _imu_residual_dead_zone = dead_zone;
+    _imu_residual_init_delay = init_delay;
+    _nm_start_time = -1.0;  // reset on every reconfigure
   }
 
 protected:
@@ -123,6 +126,8 @@ protected:
   double _imu_residual_max_depth = 0.0;      // depth gate in metres (0 = disabled)
   double _imu_residual_max_tri_error = 0.0;  // triangulation quality gate: RMS reprojection px (0 = disabled)
   double _imu_residual_dead_zone = 3.0;      // dead-zone multiplier: noise_floor = dead_zone * sigma_pix
+  double _imu_residual_init_delay = 0.0;     // seconds post-init before nm activates (0 = disabled)
+  double _nm_start_time = -1.0;              // timestamp of first update() call; set lazily
 
 };
 

--- a/ov_msckf/src/update/UpdaterMSCKF.h
+++ b/ov_msckf/src/update/UpdaterMSCKF.h
@@ -23,7 +23,10 @@
 #define OV_MSCKF_UPDATER_MSCKF_H
 
 #include <Eigen/Eigen>
+#include <fstream>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "feat/FeatureInitializerOptions.h"
 
@@ -67,6 +70,38 @@ public:
    */
   void update(std::shared_ptr<State> state, std::vector<std::shared_ptr<ov_core::Feature>> &feature_vec);
 
+  /**
+   * @brief Configure the IMU-residual per-feature noise inflation (Phase 1, Option C).
+   *
+   * When enabled, after triangulation each MSCKF feature's p_FinG is projected
+   * into cam0 at the newest clone time and compared to the actual observation.
+   * Dynamic features (large projection residual) get noise multiplier nm >> 1.
+   *
+   * @param use       Enable/disable the computation
+   * @param alpha     Multiplier scale: nm = 1 + alpha*(1 - s_imu)
+   * @param sigma_px  Decay scale for the exponential score (pixels, default 5.0)
+   */
+  void set_imu_residual_params(bool use, double alpha, double sigma_px) {
+    _use_imu_residual = use;
+    _imu_residual_alpha = alpha;
+    _imu_residual_sigma_px = sigma_px;
+  }
+
+  /**
+   * @brief Configure the per-feature CSV logger for JEPA dataset construction (Phase 2).
+   *
+   * When enabled, after each feature's nm and IMU projection are computed, a row is
+   * appended to the CSV at @p path. Disabled by default — no file I/O when false.
+   *
+   * CSV columns:
+   *   ts, feat_id, u_act, v_act, u_pred, v_pred, nm, r_px, depth,
+   *   track_len, t_prev, u_prev, v_prev, dangle_x, dangle_y, dangle_z, dt
+   *
+   * @param enable  Turn logging on/off
+   * @param path    Full output path (run number must be in the filename, e.g. feature_log_run_3.csv)
+   */
+  void set_feature_logger_params(bool enable, const std::string &path);
+
 protected:
   /// Options used during update
   UpdaterOptions _options;
@@ -76,6 +111,15 @@ protected:
 
   /// Chi squared 95th percentile table (lookup would be size of residual)
   std::map<int, double> chi_squared_table;
+
+  // IMU-residual noise inflation parameters (Phase 1, Option C)
+  bool _use_imu_residual = false;
+  double _imu_residual_alpha = 5.0;
+  double _imu_residual_sigma_px = 5.0;
+
+  // Feature logger (Phase 2 dataset collection — disabled by default)
+  bool _log_features = false;
+  std::ofstream _feat_log_file;
 };
 
 } // namespace ov_msckf

--- a/ov_msckf/src/update/UpdaterMSCKF.h
+++ b/ov_msckf/src/update/UpdaterMSCKF.h
@@ -94,12 +94,14 @@ public:
    *                     Stereo disparity at max_depth ≈ baseline*fx/max_depth.
    */
   void set_imu_residual_params(bool use, double alpha, double sigma_px,
-                               bool use_variance = false, double max_depth = 0.0) {
+                               bool use_variance = false, double max_depth = 0.0,
+                               double max_tri_error = 0.0) {
     _use_imu_residual = use;
     _imu_residual_alpha = alpha;
     _imu_residual_sigma_px = sigma_px;
     _use_residual_variance = use_variance;
     _imu_residual_max_depth = max_depth;
+    _imu_residual_max_tri_error = max_tri_error;
   }
 
 protected:
@@ -116,8 +118,9 @@ protected:
   bool _use_imu_residual = false;
   double _imu_residual_alpha = 5.0;
   double _imu_residual_sigma_px = 5.0;
-  bool _use_residual_variance = false;   // use cross-clone residual std-dev instead of single-frame
-  double _imu_residual_max_depth = 0.0; // depth gate in metres (0 = disabled)
+  bool _use_residual_variance = false;        // use cross-clone residual std-dev instead of single-frame
+  double _imu_residual_max_depth = 0.0;      // depth gate in metres (0 = disabled)
+  double _imu_residual_max_tri_error = 0.0;  // triangulation quality gate: RMS reprojection px (0 = disabled)
 
 };
 

--- a/ov_msckf/src/update/UpdaterMSCKF.h
+++ b/ov_msckf/src/update/UpdaterMSCKF.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <unordered_map>
 
+#include <opencv2/core.hpp>
+
 #include "feat/FeatureInitializerOptions.h"
 
 #include "UpdaterOptions.h"
@@ -65,42 +67,40 @@ public:
   /**
    * @brief Given tracked features, this will try to use them to update the state.
    *
-   * @param state State of the filter
-   * @param feature_vec Features that can be used for update
+   * @param state        State of the filter
+   * @param feature_vec  Features that can be used for update
    */
   void update(std::shared_ptr<State> state, std::vector<std::shared_ptr<ov_core::Feature>> &feature_vec);
 
   /**
-   * @brief Configure the IMU-residual per-feature noise inflation (Phase 1, Option C).
+   * @brief Configure the IMU-residual per-feature noise inflation.
    *
-   * When enabled, after triangulation each MSCKF feature's p_FinG is projected
-   * into cam0 at the newest clone time and compared to the actual observation.
-   * Dynamic features (large projection residual) get noise multiplier nm >> 1.
+   * Projects each feature's p_FinG into cam0 and computes a reprojection residual
+   * used to inflate MSCKF measurement noise for dynamic features (nm > 1).
    *
-   * @param use       Enable/disable the computation
-   * @param alpha     Multiplier scale: nm = 1 + alpha*(1 - s_imu)
-   * @param sigma_px  Decay scale for the exponential score (pixels, default 5.0)
+   * Two modes selectable via use_variance:
+   *   false (default) — single-frame: residual at the newest clone only.
+   *   true  (variance) — std-dev of residuals across all sliding-window clones.
+   *     Bias-invariant: triangulation error adds a constant to every r_k and
+   *     cancels in variance. Only features that actually moved show high std_r.
+   *     Falls back to nm=1 when fewer than 3 valid clone observations exist.
+   *
+   * @param use          Enable/disable
+   * @param alpha        Scale: nm = 1 + alpha*(1 - exp(-signal/sigma_px))
+   * @param sigma_px     Decay constant in pixels
+   * @param use_variance Use cross-clone residual std-dev instead of single-frame residual
+   * @param max_depth    Features beyond this depth (m) skip nm entirely (0 = disabled).
+   *                     Suppresses false inflation on poorly-triangulated far features.
+   *                     Stereo disparity at max_depth ≈ baseline*fx/max_depth.
    */
-  void set_imu_residual_params(bool use, double alpha, double sigma_px) {
+  void set_imu_residual_params(bool use, double alpha, double sigma_px,
+                               bool use_variance = false, double max_depth = 0.0) {
     _use_imu_residual = use;
     _imu_residual_alpha = alpha;
     _imu_residual_sigma_px = sigma_px;
+    _use_residual_variance = use_variance;
+    _imu_residual_max_depth = max_depth;
   }
-
-  /**
-   * @brief Configure the per-feature CSV logger for JEPA dataset construction (Phase 2).
-   *
-   * When enabled, after each feature's nm and IMU projection are computed, a row is
-   * appended to the CSV at @p path. Disabled by default — no file I/O when false.
-   *
-   * CSV columns:
-   *   ts, feat_id, u_act, v_act, u_pred, v_pred, nm, r_px, depth,
-   *   track_len, t_prev, u_prev, v_prev, dangle_x, dangle_y, dangle_z, dt
-   *
-   * @param enable  Turn logging on/off
-   * @param path    Full output path (run number must be in the filename, e.g. feature_log_run_3.csv)
-   */
-  void set_feature_logger_params(bool enable, const std::string &path);
 
 protected:
   /// Options used during update
@@ -112,14 +112,13 @@ protected:
   /// Chi squared 95th percentile table (lookup would be size of residual)
   std::map<int, double> chi_squared_table;
 
-  // IMU-residual noise inflation parameters (Phase 1, Option C)
+  // IMU-residual noise inflation parameters
   bool _use_imu_residual = false;
   double _imu_residual_alpha = 5.0;
   double _imu_residual_sigma_px = 5.0;
+  bool _use_residual_variance = false;   // use cross-clone residual std-dev instead of single-frame
+  double _imu_residual_max_depth = 0.0; // depth gate in metres (0 = disabled)
 
-  // Feature logger (Phase 2 dataset collection — disabled by default)
-  bool _log_features = false;
-  std::ofstream _feat_log_file;
 };
 
 } // namespace ov_msckf


### PR DESCRIPTION
Hello I have added **dynamic masking** support to OpenVINS, also added **configuration files for VIODE** dataset and tested dynamic masking on that dataset. This dataset also includes the segmentation information of the dynamic objects. So testing was easier.

I also added a video about dynamic masking in action. You can clearly see that algorithm doesn't track any features on these areas. I can also provide the predicted path and the ground truth path. Video quality might be low because I connected from remote desktop to host computer which runs OpenVINS.

https://github.com/user-attachments/assets/3363699e-447e-4c39-9f96-36bfe8e77833

