### PR TITLE
Fix fast propagation timestamp offset

### DIFF
--- a/ov_msckf/cmake/ROS1.cmake
+++ b/ov_msckf/cmake/ROS1.cmake
@@ -158,3 +158,10 @@ install(TARGETS test_sim_repeat
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+add_executable(test_fast_propagation src/test_fast_propagation.cpp)
+target_link_libraries(test_fast_propagation ov_msckf_lib ${thirdparty_libraries})
+install(TARGETS test_fast_propagation
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/ov_msckf/cmake/ROS2.cmake
+++ b/ov_msckf/cmake/ROS2.cmake
@@ -108,6 +108,11 @@ ament_target_dependencies(test_sim_repeat ${ament_libraries})
 target_link_libraries(test_sim_repeat ov_msckf_lib ${thirdparty_libraries})
 install(TARGETS test_sim_repeat DESTINATION lib/${PROJECT_NAME})
 
+add_executable(test_fast_propagation src/test_fast_propagation.cpp)
+ament_target_dependencies(test_fast_propagation ${ament_libraries})
+target_link_libraries(test_fast_propagation ov_msckf_lib ${thirdparty_libraries})
+install(TARGETS test_fast_propagation DESTINATION lib/${PROJECT_NAME})
+
 # Install launch and config directories
 install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch/)
 install(DIRECTORY ../config/ DESTINATION share/${PROJECT_NAME}/config/)

--- a/ov_msckf/src/state/Propagator.cpp
+++ b/ov_msckf/src/state/Propagator.cpp
@@ -151,7 +151,8 @@ bool Propagator::fast_state_propagate(std::shared_ptr<State> state, double times
 
   // First lets construct an IMU vector of measurements we need
   double time0 = cache_state_time + cache_t_off;
-  double time1 = timestamp + cache_t_off;
+  // The requested timestamp comes from the IMU callback.
+  double time1 = timestamp;
   std::vector<ov_core::ImuData> prop_data;
   {
     std::lock_guard<std::mutex> lck(imu_data_mtx);

--- a/ov_msckf/src/test_fast_propagation.cpp
+++ b/ov_msckf/src/test_fast_propagation.cpp
@@ -1,0 +1,72 @@
+/*
+ * OpenVINS: An Open Platform for Visual-Inertial Research
+ * Copyright (C) 2018-2023 Patrick Geneva
+ * Copyright (C) 2018-2023 Guoquan Huang
+ * Copyright (C) 2018-2023 OpenVINS Contributors
+ * Copyright (C) 2018-2019 Kevin Eckenhoff
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+#include "state/Propagator.h"
+#include "state/State.h"
+
+using namespace ov_msckf;
+
+int main() {
+  constexpr double gravity = 9.81;
+  constexpr double state_time_cam = 1.0;
+  constexpr double cam_to_imu_offset = 0.05;
+  constexpr double requested_time_imu = 1.15;
+  constexpr double expected_dt = 0.10;
+
+  StateOptions state_options;
+  auto state = std::make_shared<State>(state_options);
+  state->_timestamp = state_time_cam;
+  state->_calib_dt_CAMtoIMU->set_value(
+      Eigen::VectorXd::Constant(1, cam_to_imu_offset));
+
+  Propagator propagator(NoiseManager(), gravity);
+  for (int i = 0; i <= 11; ++i) {
+    ov_core::ImuData imu;
+    imu.timestamp = 1.04 + 0.01 * i;
+    imu.wm.setZero();
+    imu.am << 1.0, 0.0, gravity;
+    propagator.feed_imu(imu);
+  }
+
+  Eigen::Matrix<double, 13, 1> state_plus;
+  Eigen::Matrix<double, 12, 12> covariance;
+  if (!propagator.fast_state_propagate(
+          state, requested_time_imu, state_plus, covariance)) {
+    std::cerr << "Fast propagation unexpectedly failed." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const double expected_position_x = 0.5 * expected_dt * expected_dt;
+  const double expected_velocity_x = expected_dt;
+  if (std::abs(state_plus(4) - expected_position_x) > 1e-6 ||
+      std::abs(state_plus(7) - expected_velocity_x) > 1e-6) {
+    std::cerr << "Fast propagation used the wrong clock interval: p_x="
+              << state_plus(4) << ", v_x=" << state_plus(7) << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Fixes #461.

fast_state_propagate() is called from the ROS IMU callbacks, so its timestamp argument is already in the IMU clock domain. The cached state timestamp remains in the camera clock domain only until the cached CAM-to-IMU offset is applied to time0. Applying that offset to time1 as well advanced the published fast-propagated state by the offset a second time.

This changes time1 to use the incoming IMU timestamp directly.

Adds a deterministic regression executable that uses a 50 ms CAM-to-IMU offset and constant acceleration. Before this change it integrates 150 ms (p_x=0.01125, v_x=0.15) instead of the intended 100 ms; after the fix it verifies the intended interval. The target is included in both ROS1/non-ROS and ROS2 CMake configurations.

Validation:
- cmake -S ov_msckf -B ov_msckf/build-issue-461 -DENABLE_ROS=OFF -DENABLE_ARUCO_TAGS=OFF -DCMAKE_BUILD_TYPE=Release
- cmake --build ov_msckf/build-issue-461 --parallel 2
- LD_LIBRARY_PATH=ov_msckf/build-issue-461 ./ov_msckf/build-issue-461/test_fast_propagation