### PR TITLE
Fix mask validation with camera downsampling

### DIFF
--- a/ov_msckf/cmake/ROS1.cmake
+++ b/ov_msckf/cmake/ROS1.cmake
@@ -158,3 +158,10 @@ install(TARGETS test_sim_repeat
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+add_executable(test_mask_downsampling src/test_mask_downsampling.cpp)
+target_link_libraries(test_mask_downsampling ov_msckf_lib ${thirdparty_libraries})
+install(TARGETS test_mask_downsampling
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/ov_msckf/cmake/ROS2.cmake
+++ b/ov_msckf/cmake/ROS2.cmake
@@ -108,6 +108,11 @@ ament_target_dependencies(test_sim_repeat ${ament_libraries})
 target_link_libraries(test_sim_repeat ov_msckf_lib ${thirdparty_libraries})
 install(TARGETS test_sim_repeat DESTINATION lib/${PROJECT_NAME})
 
+add_executable(test_mask_downsampling src/test_mask_downsampling.cpp)
+ament_target_dependencies(test_mask_downsampling ${ament_libraries})
+target_link_libraries(test_mask_downsampling ov_msckf_lib ${thirdparty_libraries})
+install(TARGETS test_mask_downsampling DESTINATION lib/${PROJECT_NAME})
+
 # Install launch and config directories
 install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch/)
 install(DIRECTORY ../config/ DESTINATION share/${PROJECT_NAME}/config/)

--- a/ov_msckf/src/core/VioManagerOptions.h
+++ b/ov_msckf/src/core/VioManagerOptions.h
@@ -292,11 +292,13 @@ struct VioManagerOptions {
           }
           cv::Mat mask = cv::imread(total_mask_path, cv::IMREAD_GRAYSCALE);
           masks.insert({i, mask});
-          if (mask.cols != camera_intrinsics.at(i)->w() || mask.rows != camera_intrinsics.at(i)->h()) {
+          const int mask_width = camera_intrinsics.at(i)->w() * (downsample_cameras ? 2 : 1);
+          const int mask_height = camera_intrinsics.at(i)->h() * (downsample_cameras ? 2 : 1);
+          if (mask.cols != mask_width || mask.rows != mask_height) {
             PRINT_ERROR(RED "VioManager(): mask size does not match camera!\n" RESET);
             PRINT_ERROR(RED "\t- mask%d - %s\n" RESET, i, total_mask_path.c_str());
             PRINT_ERROR(RED "\t- mask%d - %d x %d\n" RESET, mask.cols, mask.rows);
-            PRINT_ERROR(RED "\t- cam%d - %d x %d\n" RESET, camera_intrinsics.at(i)->w(), camera_intrinsics.at(i)->h());
+            PRINT_ERROR(RED "\t- cam%d - %d x %d\n" RESET, i, mask_width, mask_height);
             std::exit(EXIT_FAILURE);
           }
         }

--- a/ov_msckf/src/test_mask_downsampling.cpp
+++ b/ov_msckf/src/test_mask_downsampling.cpp
@@ -1,0 +1,74 @@
+/*
+ * OpenVINS: An Open Platform for Visual-Inertial Research
+ * Copyright (C) 2018-2023 Patrick Geneva
+ * Copyright (C) 2018-2023 Guoquan Huang
+ * Copyright (C) 2018-2023 OpenVINS Contributors
+ * Copyright (C) 2018-2019 Kevin Eckenhoff
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <opencv2/imgcodecs.hpp>
+
+#include "core/VioManagerOptions.h"
+
+using namespace ov_msckf;
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "Usage: test_mask_downsampling <config-directory>" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const std::string config_dir = argv[1];
+  const std::string test_config_path = config_dir + "/test_mask_downsampling.yaml";
+  const std::string test_mask_path = config_dir + "/test_mask_downsampling.png";
+  const cv::Mat mask(480, 752, CV_8UC1, cv::Scalar(255));
+
+  if (!cv::imwrite(test_mask_path, mask)) {
+    std::cerr << "Unable to create test mask." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  {
+    std::ofstream config(test_config_path);
+    config << "%YAML:1.0\nmax_cameras: 2\ngravity_mag: 9.81\ndownsample_cameras: true\nuse_mask: true\n"
+           << "mask0: \"test_mask_downsampling.png\"\nmask1: \"test_mask_downsampling.png\"\n"
+           << "relative_config_imu: \"kalibr_imu_chain.yaml\"\nrelative_config_imucam: \"kalibr_imucam_chain.yaml\"\n";
+  }
+
+  auto parser = std::make_shared<ov_core::YamlParser>(test_config_path);
+  VioManagerOptions options;
+  options.state_options.num_cameras = 2;
+  options.downsample_cameras = true;
+  options.print_and_load_state(parser);
+
+  std::remove(test_config_path.c_str());
+  std::remove(test_mask_path.c_str());
+
+  if (options.masks.at(0).size() != mask.size() || options.camera_intrinsics.at(0)->w() != 376 ||
+      options.camera_intrinsics.at(0)->h() != 240) {
+    std::cerr << "Downsampled camera did not retain a mask in the input image coordinate system." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Problem

With `downsample_cameras: true`, camera intrinsics are reduced during configuration loading but input images are reduced later in `VioManager::track_image_and_update()`. The previous validation compared masks against the already-downsampled intrinsics, so users had to provide half-resolution masks. Those masks were then downsampled a second time alongside their images, causing mask/image size mismatches and out-of-bounds mask access during tracking.

## Fix

Validate each configured mask in the input image coordinate system. When camera downsampling is enabled, the expected mask dimensions are twice the stored camera-intrinsic dimensions. The existing tracking path then downsamples the image and mask together exactly once.

## Regression coverage

`test_mask_downsampling` creates full-resolution 752x480 masks, loads a two-camera configuration with `downsample_cameras: true`, and verifies that the masks remain 752x480 while the camera model is 376x240. This exercises the configuration/tracking boundary that previously required an incorrectly sized mask. The target is included in both ROS1 and ROS2 CMake configurations.

## Validation

```bash
cmake -S ov_msckf -B ov_msckf/build-issue-522 -DENABLE_ROS=OFF -DENABLE_ARUCO_TAGS=OFF
cmake --build ov_msckf/build-issue-522 -j2
./ov_msckf/build-issue-522/test_mask_downsampling ./config/euroc_mav
```

The complete no-ROS build and the new regression pass locally. Existing simulation executables require the optional `ov_data/sim/tum_corridor1_512_16_okvis.txt` trajectory, which is not present in this checkout.

Fixes #522